### PR TITLE
Move to and enforce camelCase vars and params

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
         }
     },
     "scripts": {
-        "phpcs": "phpcs --standard=PSR2 ./src ./tests",
-        "phpcbf": "phpcbf --standard=PSR2 ./src ./tests",
+        "phpcs": "phpcs --standard=phpcs-ruleset.xml ./src ./tests",
+        "phpcbf": "phpcbf --standard=phpcs-ruleset.xml ./src ./tests",
         "test": "phpunit ./tests",
         "lint": "find src -name '*.php' -exec php -l {} \\;"
     }

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<ruleset name="php-tuf Coding Standard">
+    <!-- We basically follow PSR-2 -->
+    <rule ref="PSR2"/>
+
+    <!-- Since PSR-2 / PSR-12 say nothing about variable lettercase, we choose a standard. -->
+    <rule ref="Squiz.NamingConventions.ValidVariableName"/>
+</ruleset>

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -4,5 +4,7 @@
     <rule ref="PSR2"/>
 
     <!-- Since PSR-2 / PSR-12 say nothing about variable lettercase, we choose a standard. -->
-    <rule ref="Squiz.NamingConventions.ValidVariableName"/>
+    <rule ref="Squiz.NamingConventions.ValidVariableName.NotCamelCaps"/>
+    <rule ref="Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps"/>
+    <rule ref="Squiz.NamingConventions.ValidVariableName.StringNotCamelCaps"/>
 </ruleset>

--- a/src/Client/DurableStorage/FilesystemDurableStorage.php
+++ b/src/Client/DurableStorage/FilesystemDurableStorage.php
@@ -7,7 +7,8 @@ namespace Tuf\Client\DurableStorage;
  * Class FilesystemLocalState
  *
  * A simple implementation of LocalStateInterface using the filesystem.
- * Applications might want to provide an alternative implementation with better performance and error handling.
+ * Applications might want to provide an alternative implementation with
+ * better performance and error handling.
  *
  * @TODO Add tests for this class.
  */

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -19,9 +19,9 @@ class UpdaterTest extends TestCase
         ),
         );
         $updater = new Updater('repo1', $mirrors);
-        $fixture_target = 'testtarget.txt';
-        $target_stream = fopen('data://text/plain,' . 'Test File', 'r');
-        $this->assertTrue($updater->validateTarget($fixture_target, $target_stream));
+        $fixtureTarget = 'testtarget.txt';
+        $targetStream = fopen('data://text/plain,' . 'Test File', 'r');
+        $this->assertTrue($updater->validateTarget($fixtureTarget, $targetStream));
     }
 
   /**

--- a/tests/DurableStorage/InMemoryBackend.php
+++ b/tests/DurableStorage/InMemoryBackend.php
@@ -7,7 +7,8 @@ namespace Tuf\Tests\DurableStorage;
  * Class InMemoryBackend
  *
  * Provides a trivial implementation of \ArrayAccess for testing.
- * Brought to you by https://www.php.net/manual/en/class.arrayaccess and ctrl+v.
+ * Brought to you by https://www.php.net/manual/en/class.arrayaccess and
+ * the letters c,t,r,l and v.
  */
 class InMemoryBackend implements \ArrayAccess
 {


### PR DESCRIPTION
Per discussion on the call early this morning. We were being inconsistent. Folks who were around at the time (@tedbow @xjm @mbaynton others?) decided on camelCase because it's probably more familiar to non-Drupal projects and any little niceties we can do for broader adoption are good.