### PR TITLE
[BUGFIX] Re-add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+certifi==2020.6.20
+cffi==1.14.1
+chardet==3.0.4
+colorama==0.4.3
+cryptography==3.0
+idna==2.10
+iso8601==0.1.12
+pycparser==2.20
+PyNaCl==1.4.0
+python-dateutil==2.8.1
+requests==2.24.0
+securesystemslib==0.15.0
+six==1.15.0
+tuf==0.12.2
+urllib3==1.25.10


### PR DESCRIPTION
In order to run the server-side (python-based)
implementation, the requirements.txt as
described in the README.md should be re-added.