### PR TITLE
Require storage implementation in the constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PHP-TUF
 
-PHP-TUF is a PHP implementation of [The Update Framework(TUF)](https://theupdateframework.io/) to provide signing and verification for secure PHP application updates. [Read the TUF specification](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md) for more information on how TUF is intended to work and the security it provides.
+PHP-TUF is a PHP implementation of [The Update Framework (TUF)](https://theupdateframework.io/) to provide signing and verification for secure PHP application updates. [Read the TUF specification](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md) for more information on how TUF is intended to work and the security it provides.
 
 PHP-TUF project development is primarily focused on supporting secure automated updates for PHP CMSes. Contributing projects:
 - [Drupal](https://www.drupal.org/)

--- a/README.md
+++ b/README.md
@@ -1,31 +1,16 @@
 # PHP-TUF
 
-## What is PHP-TUF?
+PHP-TUF is a PHP implementation of [The Update Framework(TUF)](https://theupdateframework.io/) to provide signing and verification for secure PHP application updates. [Read the TUF specification](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md) for more information on how TUF is intended to work.
 
 ## PHP-TUF server requirements
 
-We recommend using the [default CLI implementation](https://github.com/theupdateframework/tuf/blob/develop/docs/CLI.md) (a Python application) to generate keys and signatures as a part of your project's release creation process.
+We recommend using the [default CLI implementation](https://github.com/theupdateframework/tuf/blob/develop/docs/CLI.md) (a Python application) to generate keys and signatures as a part of your project's release creation process. This will require:
+- Python 3.8+
+- PIP 19+
 
 @todo More detailed instructions.
 
-## PHP-TUF client requirements
-
-The PHP-TUF client is designed to provide TUF verification to PHP applications for target signatures.
-
-- Minimum required PHP version: 7.2
-- Requires `ext-json`
-- The `paragonie/sodium_compat` dependency provides a polyfill for the Sodium
-  cryptography library; however, installing `ext-sodium` is recommended for
-  better performance and security.
-
-## Running the tests
-1. Ensure you have all required dependencies by running `composer install`.
-2. Run `composer test` at the project's root.
-
-## Code Style
-Run `composer phpcs` to check for code style compliance. The code adheres to PSR-2 code standards.
-
-## Environment Setup for Python TUF CLI
+### Server Environment Setup for Python TUF CLI
 
 1. Install Python 3.8+ and PIP 19+ (not tested on earlier but may work).
 1. Set up a virtual environment:
@@ -37,7 +22,26 @@ Run `composer phpcs` to check for code style compliance. The code adheres to PSR
 
        pip install -r requirements.txt
 
-## Test Fixtures Setup
+## PHP-TUF client requirements
+
+The PHP-TUF client is designed to provide TUF verification to PHP applications for target signatures.
+
+- Minimum required PHP version: 7.2
+- Requires `ext-json`
+- The `paragonie/sodium_compat` dependency provides a polyfill for the Sodium
+  cryptography library; however, installing `ext-sodium` is recommended for
+  better performance and security.
+
+## Code Style
+Run `composer phpcs` to check for code style compliance. The code adheres to PSR-2 code standards.
+
+## Testing
+
+### Running the tests
+1. Ensure you have all required dependencies by running `composer install`.
+2. Run `composer test` at the project's root.
+
+### Test Fixtures Setup
 
 1. Start a `fixtures` directory:
 
@@ -49,7 +53,7 @@ Run `composer phpcs` to check for code style compliance. The code adheres to PSR
        echo "Test File" > testtarget.txt
        repo.py --path=fixtures/ --add testtarget.txt
 
-## Using Test Fixtures
+### Using Test Fixtures
 
 1. From `fixtures/tufrepo`:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We recommend using the [default CLI implementation](https://github.com/theupdate
 
 @todo More detailed instructions.
 
-### Server Environment Setup for Python TUF CLI
+### Server environment setup for the Python TUF CLI
 
 1. Install Python 3.8+ and PIP 19+ (not tested on earlier but may work).
 1. Set up a virtual environment:
@@ -32,7 +32,7 @@ We recommend using the [default CLI implementation](https://github.com/theupdate
 
        pip install -r requirements.txt
 
-## Code Style
+## Code style
 Run `composer phpcs` to check for code style compliance. The code adheres to PSR-2 code standards.
 
 ## Testing
@@ -41,7 +41,7 @@ Run `composer phpcs` to check for code style compliance. The code adheres to PSR
 1. Ensure you have all required dependencies by running `composer install`.
 2. Run `composer test` at the project's root.
 
-### Test Fixtures Setup
+### Test fixtures setup
 
 1. [Set up the TUF server environment locally](#server-environment-setup-for-python-tuf-cli).
 
@@ -55,7 +55,7 @@ Run `composer phpcs` to check for code style compliance. The code adheres to PSR
        echo "Test File" > testtarget.txt
        repo.py --path=fixtures/ --add testtarget.txt
 
-### Using Test Fixtures
+### Using test fixtures
 
 1. From `fixtures/tufrepo`:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # PHP-TUF
 
-PHP-TUF is a PHP implementation of [The Update Framework(TUF)](https://theupdateframework.io/) to provide signing and verification for secure PHP application updates. [Read the TUF specification](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md) for more information on how TUF is intended to work.
+PHP-TUF is a PHP implementation of [The Update Framework(TUF)](https://theupdateframework.io/) to provide signing and verification for secure PHP application updates. [Read the TUF specification](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md) for more information on how TUF is intended to work and the security it provides.
+
+PHP-TUF project development is primarily focused on supporting secure automated updates for PHP CMSes. Contributing projects:
+- [Drupal](https://www.drupal.org/)
+- [TYPO3](https://typo3.org/)
+- [Joomla](https://www.joomla.org/)
 
 ## PHP-TUF client requirements
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ We recommend using the [default CLI implementation](https://github.com/theupdate
 The PHP-TUF client is designed to provide TUF verification to PHP applications for target signatures.
 
 - Minimum required PHP version: 7.2
-- Requires ext-sodium and ext-json
+- Requires `ext-json`
+- The `paragonie/sodium_compat` dependency provides a polyfill for the Sodium
+  cryptography library; however, installing `ext-sodium` is recommended for
+  better performance and security.
 
 ## Running the tests
 1. Ensure you have all required dependencies by running `composer install`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 PHP-TUF is a PHP implementation of [The Update Framework (TUF)](https://theupdateframework.io/) to provide signing and verification for secure PHP application updates. [Read the TUF specification](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md) for more information on how TUF is intended to work and the security it provides.
 
-PHP-TUF project development is primarily focused on supporting secure automated updates for PHP CMSes. Contributing projects:
+PHP-TUF project development is primarily focused on supporting secure automated updates for PHP CMSes, although it will also work for any PHP application or Composer project. Contributing projects:
 - [Drupal](https://www.drupal.org/)
 - [TYPO3](https://typo3.org/)
 - [Joomla](https://www.joomla.org/)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 PHP-TUF is a PHP implementation of [The Update Framework(TUF)](https://theupdateframework.io/) to provide signing and verification for secure PHP application updates. [Read the TUF specification](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md) for more information on how TUF is intended to work.
 
+## PHP-TUF client requirements
+
+The PHP-TUF client is designed to provide TUF verification to PHP applications for target signatures.
+
+- Minimum required PHP version: 7.2
+- Requires `ext-json`
+- The `paragonie/sodium_compat` dependency provides a polyfill for the Sodium
+  cryptography library; however, installing `ext-sodium` is recommended for
+  better performance and security.
+  
 ## PHP-TUF server requirements
 
 We recommend using the [default CLI implementation](https://github.com/theupdateframework/tuf/blob/develop/docs/CLI.md) (a Python application) to generate keys and signatures as a part of your project's release creation process. This will require:
@@ -21,16 +31,6 @@ We recommend using the [default CLI implementation](https://github.com/theupdate
 1. Install dependencies and TUF:
 
        pip install -r requirements.txt
-
-## PHP-TUF client requirements
-
-The PHP-TUF client is designed to provide TUF verification to PHP applications for target signatures.
-
-- Minimum required PHP version: 7.2
-- Requires `ext-json`
-- The `paragonie/sodium_compat` dependency provides a polyfill for the Sodium
-  cryptography library; however, installing `ext-sodium` is recommended for
-  better performance and security.
 
 ## Code Style
 Run `composer phpcs` to check for code style compliance. The code adheres to PSR-2 code standards.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Run `composer phpcs` to check for code style compliance. The code adheres to PSR
 
 ### Test Fixtures Setup
 
+1. [Set up the TUF server environment locally](#server-environment-setup-for-python-tuf-cli).
+
 1. Start a `fixtures` directory:
 
        mkdir fixtures

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,10 @@
     "require": {
         "php": ">=7.2.5",
         "ext-json": "*",
-        "ext-sodium": "*"
+        "paragonie/sodium_compat": "^1.13"
+    },
+    "suggest": {
+        "ext-libsodium": "Provides faster verification of updates"
     },
     "autoload": {
         "psr-4": {

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -28,25 +28,37 @@ class Updater
    */
     protected $mirrors;
 
+    /**
+     * The permanent storage (e.g., filesystem storage) for the client metadata.
+     *
+     * @var \ArrayAccess
+     */
     protected $durableStorage;
 
   /**
    * Updater constructor.
    *
-   * @param $repositoryName
-   *   A name the application assigns to the repository used by this Updater.
-   * @param $mirrors
-   * @param $durableStorage
-   *   An implementation of \ArrayAccess that stores its contents durably, as
-   *   in to disk or a database. Values written for a given repository should
-   *   be exposed to future instantiations of the Updater that interact with
-   *   the same repository.
+   * @param string $repositoryName
+   *     A name the application assigns to the repository used by this Updater.
+   * @param mixed[][] $mirrors
+   *     A nested array of mirrors to use for fetching signing data from the
+   *     repository. Each child array contains information about the mirror:
+   *     - url_prefix: (string) The URL for the mirror.
+   *     - metadata_path: (string) The path within the repository for signing
+   *       metadata.
+   *     - targets_path: (string) The path within the repository for targets
+   *       (the actual update data that has been signed).
+   *     - confined_target_dirs: (array) @todo What is this for?
+   * @param \ArrayAccess $durableStorage
+   *     An implementation of \ArrayAccess that stores its contents durably, as
+   *     in to disk or a database. Values written for a given repository should
+   *     be exposed to future instantiations of the Updater that interact with
+   *     the same repository.
    */
-    public function __construct(string $repositoryName, array $mirrors, \ArrayAccess $durableStorage)
+    public function __construct(string $repositoryName, array $mirrors, \ArrayAccess $durableStorage) : void
     {
         $this->repoName = $repositoryName;
         $this->mirrors = $mirrors;
-
         $this->durableStorage = new ValidatingArrayAccessAdapter($durableStorage);
     }
 

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -55,7 +55,7 @@ class Updater
    *     be exposed to future instantiations of the Updater that interact with
    *     the same repository.
    */
-    public function __construct(string $repositoryName, array $mirrors, \ArrayAccess $durableStorage) : void
+    public function __construct(string $repositoryName, array $mirrors, \ArrayAccess $durableStorage)
     {
         $this->repoName = $repositoryName;
         $this->mirrors = $mirrors;

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -9,9 +9,14 @@ use Tuf\Tests\DurableStorage\InMemoryBackend;
 class UpdaterTest extends TestCase
 {
     /**
+     * Returns a memory-based updater populated with the test fixtures.
+     *
      * @return Updater
+     *   The test updater, which uses the 'current' test fixtures in the
+     *   tufclient/tufrepo/metadata/current/ directory and a localhost HTTP
+     *   mirror.
      */
-    protected function getSystemInTest()
+    protected function getSystemInTest() : Updater
     {
         $mirrors = [
             'mirror1' => [
@@ -22,13 +27,26 @@ class UpdaterTest extends TestCase
             ],
         ];
 
-        // Memory storage used so tests can write without permanent side-effects.
+        // Use the memory storage used so tests can write without permanent
+        // side-effects.
         $localRepo = $this->populateMemoryStorageFromFixtures('tufclient/tufrepo/metadata/current');
         $updater = new Updater('repo1', $mirrors, $localRepo);
         return $updater;
     }
 
-    public function populateMemoryStorageFromFixtures($path)
+    /**
+     * Uses test fixtures at a given path to populate a memory storage backend.
+     *
+     * @param string $path
+     *   The relative path (within the fixtures directory) for the client data.
+     *
+     * @return InMemoryBackend
+     *   Memory storage containing the test client data.
+     *
+     * @throws \RuntimeException
+     *   Thrown if the relative path is invalid.
+     */
+    public function populateMemoryStorageFromFixtures(string $path) : InMemoryBackend
     {
         $realpath = realpath(__DIR__ . "/../../fixtures/$path");
         if ($realpath === false || !is_dir($realpath)) {

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -4,9 +4,54 @@ namespace Tuf\Tests\Client;
 
 use PHPUnit\Framework\TestCase;
 use Tuf\Client\Updater;
+use Tuf\Tests\DurableStorage\InMemoryBackend;
 
 class UpdaterTest extends TestCase
 {
+    /**
+     * @return Updater
+     */
+    protected function getSystemInTest()
+    {
+        $mirrors = [
+            'mirror1' => [
+                'url_prefix' => 'http://localhost:8001',
+                'metadata_path' => 'metadata',
+                'targets_path' => 'targets',
+                'confined_target_dirs' => [],
+            ],
+        ];
+
+        // Memory storage used so tests can write without permanent side-effects.
+        $localRepo = $this->populateMemoryStorageFromFixtures('tufclient/tufrepo/metadata/current');
+        $updater = new Updater('repo1', $mirrors, $localRepo);
+        return $updater;
+    }
+
+    public function populateMemoryStorageFromFixtures($path)
+    {
+        $realpath = realpath(__DIR__ . "/../../fixtures/$path");
+        if ($realpath === false || !is_dir($realpath)) {
+            throw new \RuntimeException("Client repository fixtures directory not found at $path");
+        }
+
+        $storage = new InMemoryBackend();
+
+        $iter = new \FilesystemIterator(
+            $realpath,
+            \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::KEY_AS_FILENAME
+        );
+        foreach ($iter as $filename => $info) {
+            /**
+             * @var $info \SplFileInfo
+             */
+            if ($info->isFile() && preg_match("|\.json$|", $filename)) {
+                $storage[$filename] = file_get_contents($info->getRealPath());
+            }
+        }
+
+        return $storage;
+    }
 
     public function testUpdateSuccessful()
     {
@@ -18,7 +63,7 @@ class UpdaterTest extends TestCase
         'confined_target_dirs' => [],
         ],
         ];
-        $updater = new Updater('repo1', $mirrors);
+        $updater = $this->getSystemInTest();
         $fixtureTarget = 'testtarget.txt';
         $targetStream = fopen('data://text/plain,' . 'Test File', 'r');
         $this->assertTrue($updater->validateTarget($fixtureTarget, $targetStream));

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -55,14 +55,14 @@ class UpdaterTest extends TestCase
 
         $storage = new InMemoryBackend();
 
+        // Loop through and load files in the given path.
         $fsIterator = new \FilesystemIterator(
             $realpath,
             \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::KEY_AS_FILENAME
         );
         foreach ($fsIterator as $filename => $info) {
-            /**
-             * @var $info \SplFileInfo
-             */
+            // Only load json files.
+            /** @var $info \SplFileInfo */
             if ($info->isFile() && preg_match("|\.json$|", $filename)) {
                 $storage[$filename] = file_get_contents($info->getRealPath());
             }

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -62,7 +62,7 @@ class UpdaterTest extends TestCase
             \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::KEY_AS_FILENAME
         );
         foreach ($fsIterator as $filename => $info) {
-            // Only load json files.
+            // Only load JSON files.
             /** @var $info \SplFileInfo */
             if ($info->isFile() && preg_match("|\.json$|", $filename)) {
                 $storage[$filename] = file_get_contents($info->getRealPath());

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -12,9 +12,9 @@ class UpdaterTest extends TestCase
      * Returns a memory-based updater populated with the test fixtures.
      *
      * @return Updater
-     *   The test updater, which uses the 'current' test fixtures in the
-     *   tufclient/tufrepo/metadata/current/ directory and a localhost HTTP
-     *   mirror.
+     *     The test updater, which uses the 'current' test fixtures in the
+     *     tufclient/tufrepo/metadata/current/ directory and a localhost HTTP
+     *     mirror.
      */
     protected function getSystemInTest() : Updater
     {
@@ -38,13 +38,14 @@ class UpdaterTest extends TestCase
      * Uses test fixtures at a given path to populate a memory storage backend.
      *
      * @param string $path
-     *   The relative path (within the fixtures directory) for the client data.
+     *     The relative path (within the fixtures directory) for the client
+     *     data.
      *
      * @return InMemoryBackend
-     *   Memory storage containing the test client data.
+     *     Memory storage containing the test client data.
      *
      * @throws \RuntimeException
-     *   Thrown if the relative path is invalid.
+     *     Thrown if the relative path is invalid.
      */
     public function populateMemoryStorageFromFixtures(string $path) : InMemoryBackend
     {

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -55,11 +55,11 @@ class UpdaterTest extends TestCase
 
         $storage = new InMemoryBackend();
 
-        $iter = new \FilesystemIterator(
+        $fsIterator = new \FilesystemIterator(
             $realpath,
             \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::KEY_AS_FILENAME
         );
-        foreach ($iter as $filename => $info) {
+        foreach ($fsIterator as $filename => $info) {
             /**
              * @var $info \SplFileInfo
              */


### PR DESCRIPTION
To allow applications to provide their database/filesystem/whatever implementation.

This also updates the tests to use an in-memory copy of the fixtures so
that the test runs are free to write back to the local repo without
creating lasting side-effects.