### PR TITLE
Remove unneeded public and protected members from custom exception classes, and add docs and typehints

### DIFF
--- a/src/Exception/FormatException.php
+++ b/src/Exception/FormatException.php
@@ -27,5 +27,4 @@ class FormatException extends TufException
         $message = $message . sprintf(": %s", $malformedValue);
         parent::__construct($message, 0, $previous);
     }
-
 }

--- a/src/Exception/FormatException.php
+++ b/src/Exception/FormatException.php
@@ -7,7 +7,6 @@ namespace Tuf\Exception;
  */
 class FormatException extends TufException
 {
-    protected $malformedValue;
 
     public function __construct($malformedValue, $message = "", \Throwable $previous = null)
     {
@@ -15,12 +14,7 @@ class FormatException extends TufException
             $message = 'Bad format';
         }
         $message = $message . sprintf(": %s", $malformedValue);
-        $this->malformedValue = $malformedValue;
         parent::__construct($message, 0, $previous);
     }
 
-    public function getMalformedValue()
-    {
-        return $this->malformedValue;
-    }
 }

--- a/src/Exception/FormatException.php
+++ b/src/Exception/FormatException.php
@@ -8,7 +8,18 @@ namespace Tuf\Exception;
 class FormatException extends TufException
 {
 
-    public function __construct($malformedValue, $message = "", \Throwable $previous = null)
+    /**
+     * Constructs the exception.
+     *
+     * @param string $malformedValue
+     *     The malformed value string that caused the exception.
+     * @param string $message
+     *     (optional) The exception message to use. If blank, a default message
+     *     will be used.
+     * @param \Throwable|null $previous
+     *     (optional) The previous exception, if any, for exception chaining.
+     */
+    public function __construct(string $malformedValue, string $message = "", \Throwable $previous = null)
     {
         if (empty($message)) {
             $message = 'Bad format';

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -9,18 +9,6 @@ namespace Tuf\Exception;
  */
 class NotFoundException extends TufException
 {
-    /**
-     * @var string $key
-     *   The unique identifier (ID, file path, etc.) for the item that was not
-     *   found.
-     */
-    public $key;
-
-    /**
-     * @var string $itemType
-     *   The type of item (signing key, file, etc.) that was not found.
-     */
-    public $itemType;
 
     public function __construct($key = "", $itemType = "item", \Throwable $previous = null)
     {
@@ -28,8 +16,6 @@ class NotFoundException extends TufException
         if ($key != "") {
             $message = "$itemType not found: $key";
         }
-        $this->key = $key;
-        $this->itemType = $itemType;
         parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -10,7 +10,20 @@ namespace Tuf\Exception;
 class NotFoundException extends TufException
 {
 
-    public function __construct($key = "", $itemType = "item", \Throwable $previous = null)
+    /**
+     * Constructs the exception.
+     *
+     * @param string $key
+     *     (optional) The unique identifier, if any, for the item that was not
+     *     found.
+     * @param string $itemType
+     *     (optional) The type of item (signing key, file, etc.) that was not
+     *     found. Used to construct the exception message. If left blank, the
+     *     word 'item' will be used by default.
+     * @param \Throwable|null $previous
+     *     (optional) The previous exception, if any, for exception chaining.
+     */
+    public function __construct(string $key = '', string $itemType = 'item', \Throwable $previous = null)
     {
         $message = "$itemType not found";
         if ($key != "") {


### PR DESCRIPTION
The existing typed `FormatException` and `NotFoundException` classes have some member properties and methods that are never used again:
- `NotFoundException` adds _public_ properties that are never used after initialization.
- `FormatException` adds a protected property and public getter for it that are also never used after initialization.

If we want additional API on the exceptions in the future, we can add it back, but ideally we should not define any public API unless it's used to avoid the need to provide BC for stuff we don't actually need. Offhand, I can't think of a single time I've needed custom API for an exception after it's thrown aside from the exception type itself.

The PR also adds the missing API docs and signature typehints for these two exception classes.