### PR TITLE
Clean up KeyDBTest

### DIFF
--- a/tests/KeyDBTest.php
+++ b/tests/KeyDBTest.php
@@ -22,13 +22,13 @@ class KeyDBTest extends TestCase
     {
         return [
           "case 1" => [
-            0 => [
+            'metadata' => [
                   "keyid_hash_algorithms" => ['sha256', 'sha512'],
                   "keytype" => "ed25519",
                   "keyval" => ["public" => "edcd0a32a07dce33f7c7873aaffbff36d20ea30787574ead335eefd337e4dacd"],
                   "scheme" => "ed25519"
                 ],
-            1 => [
+            'expected' => [
               "59a4df8af818e9ed7abe0764c0b47b4240952aa0d179b5b78346c470ac30278d",
               "594e8b4bdafc33fd87e9d03a95be13a6dc93a836086614fd421116d829af68d8f0110ae93e3dde9a246897fd85171455ea53191b"
               . "b96cf9e589ba047d057dbd66"

--- a/tests/KeyDBTest.php
+++ b/tests/KeyDBTest.php
@@ -11,10 +11,10 @@ class KeyDBTest extends TestCase
      * @param $metadata
      * @dataProvider computeKeyIdProvider
      */
-    public function testComputeKeyId($metadata, $want)
+    public function testComputeKeyId($metadata, $expected)
     {
         $actual = KeyDB::computeKeyIds($metadata);
-        $this->assertEquals($want, $actual);
+        $this->assertEquals($expected, $actual);
     }
 
     public function computeKeyIdProvider()

--- a/tests/KeyDBTest.php
+++ b/tests/KeyDBTest.php
@@ -12,9 +12,9 @@ class KeyDBTest extends TestCase
      * @param $metadata
      * @dataProvider computeKeyIdProvider
      */
-    public function testComputeKeyId($keyMeta, $want)
+    public function testComputeKeyId($metadata, $want)
     {
-        $actual = KeyDB::computeKeyIds($keyMeta);
+        $actual = KeyDB::computeKeyIds($metadata);
         $this->assertEquals($want, $actual);
     }
 

--- a/tests/KeyDBTest.php
+++ b/tests/KeyDBTest.php
@@ -25,12 +25,11 @@ class KeyDBTest extends TestCase
                   'keyid_hash_algorithms' => ['sha256', 'sha512'],
                   'keytype' => 'ed25519',
                   'keyval' => ['public' => 'edcd0a32a07dce33f7c7873aaffbff36d20ea30787574ead335eefd337e4dacd'],
-                  'scheme' => 'ed25519'
+                  'scheme' => 'ed25519',
                 ],
             'expected' => [
               '59a4df8af818e9ed7abe0764c0b47b4240952aa0d179b5b78346c470ac30278d',
-              '594e8b4bdafc33fd87e9d03a95be13a6dc93a836086614fd421116d829af68d8f0110ae93e3dde9a246897fd85171455ea53191b'
-              . 'b96cf9e589ba047d057dbd66'
+              '594e8b4bdafc33fd87e9d03a95be13a6dc93a836086614fd421116d829af68d8f0110ae93e3dde9a246897fd85171455ea53191bb96cf9e589ba047d057dbd66',
             ]
           ]
         ];

--- a/tests/KeyDBTest.php
+++ b/tests/KeyDBTest.php
@@ -5,19 +5,38 @@ namespace Tuf\Tests;
 use PHPUnit\Framework\TestCase;
 use Tuf\KeyDB;
 
+/**
+ * Tests KeyDB functionality.
+ */
 class KeyDBTest extends TestCase
 {
     /**
-     * @param $metadata
+     * Tests that computed key IDs match expected values in the repository.
+     *
      * @dataProvider computeKeyIdProvider
+     *
+     * @param mixed[] $metadata
+     *     The metadata for which to compute keys.
+     * @param string[] $expected
+     *     The expected key values.
+     *
+     * @return void
      */
-    public function testComputeKeyId($metadata, $expected)
+    public function testComputeKeyId(array $metadata, array $expected) : void
     {
         $actual = KeyDB::computeKeyIds($metadata);
         $this->assertEquals($expected, $actual);
     }
 
-    public function computeKeyIdProvider()
+    /**
+     * Data provider for testComputeKeyId().
+     *
+     * @return array[][]
+     *     An associative array of test cases, each containing:
+     *     - metadata: The key metadata to check.
+     *     - expected: The expected keys from the repository.
+     */
+    public function computeKeyIdProvider() : array
     {
         return [
           'case 1' => [

--- a/tests/KeyDBTest.php
+++ b/tests/KeyDBTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Tuf\Tests;
 
 use PHPUnit\Framework\TestCase;
@@ -21,17 +20,17 @@ class KeyDBTest extends TestCase
     public function computeKeyIdProvider()
     {
         return [
-          "case 1" => [
+          'case 1' => [
             'metadata' => [
-                  "keyid_hash_algorithms" => ['sha256', 'sha512'],
-                  "keytype" => "ed25519",
-                  "keyval" => ["public" => "edcd0a32a07dce33f7c7873aaffbff36d20ea30787574ead335eefd337e4dacd"],
-                  "scheme" => "ed25519"
+                  'keyid_hash_algorithms' => ['sha256', 'sha512'],
+                  'keytype' => 'ed25519',
+                  'keyval' => ['public' => 'edcd0a32a07dce33f7c7873aaffbff36d20ea30787574ead335eefd337e4dacd'],
+                  'scheme' => 'ed25519'
                 ],
             'expected' => [
-              "59a4df8af818e9ed7abe0764c0b47b4240952aa0d179b5b78346c470ac30278d",
-              "594e8b4bdafc33fd87e9d03a95be13a6dc93a836086614fd421116d829af68d8f0110ae93e3dde9a246897fd85171455ea53191b"
-              . "b96cf9e589ba047d057dbd66"
+              '59a4df8af818e9ed7abe0764c0b47b4240952aa0d179b5b78346c470ac30278d',
+              '594e8b4bdafc33fd87e9d03a95be13a6dc93a836086614fd421116d829af68d8f0110ae93e3dde9a246897fd85171455ea53191b'
+              . 'b96cf9e589ba047d057dbd66'
             ]
           ]
         ];


### PR DESCRIPTION
* Fix $metadata parameter name to match documentation.
* Label data provider arrays with parameter names.
* Code style nitpicks.
* Tweet-length lines are no longer CI fails, so remove concatenation workaround. Also, add missing trailing commas.
* While $want is an amusing parameter name, it is not totally clear. $expected is more standard for a test.
* Add missing typehints and class and method docs.