### PR TITLE
Update PEP 458 link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,4 +108,4 @@ dependency information](DEPENDENCIES.md).
   * [CLI](https://github.com/theupdateframework/tuf/blob/develop/docs/CLI.md)
   * [Python API Readme](https://github.com/theupdateframework/tuf/blob/develop/tuf/client/README.md)
 * [TUF Specification](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md)
-* [PIP + TUF Integration](https://github.com/theupdateframework/pep-on-pypi-with-tuf)
+* [PIP + TUF Integration](https://www.python.org/dev/peps/pep-0458/)


### PR DESCRIPTION
The prior link is an archived GitHub repository. An updated PEP 458,
documenting the proposed integration of TUF into PyPI, is now maintained
on Python's PEP infrastructure.
