### PR TITLE
Make sure directories exist before cleaning them up in test fixture generation

### DIFF
--- a/fixtures/generate.py
+++ b/fixtures/generate.py
@@ -1,4 +1,5 @@
 from tuf.repository_tool import *
+import os
 import shutil
 
 # This file largely derives from the TUF tutorial:
@@ -13,9 +14,9 @@ def write_and_import_keypair(filename):
     return (public_key, private_key)
 
 # Clean up
-shutil.rmtree('tufrepo/')
-shutil.rmtree('tufkeystore/')
-shutil.rmtree('tufclient/')
+if os.path.isdir('tufrepo'): shutil.rmtree('tufrepo/')
+if os.path.isdir('tufkeystore'): shutil.rmtree('tufkeystore/')
+if os.path.isdir('tufclient'): shutil.rmtree('tufclient/')
 
 # Create and Import Keypairs
 (public_root_key, private_root_key) = write_and_import_keypair('root')


### PR DESCRIPTION
Before making this change, this happened on an initial run:

```
$ python generate.py
Traceback (most recent call last):
  File "generate.py", line 17, in <module>
    shutil.rmtree('tufkeystore/')
  File "/usr/local/Cellar/python@3.8/3.8.5/Frameworks/Python.framework/Versions/3.8/lib/python3.8/shutil.py", line 706, in rmtree
    onerror(os.lstat, path, sys.exc_info())
  File "/usr/local/Cellar/python@3.8/3.8.5/Frameworks/Python.framework/Versions/3.8/lib/python3.8/shutil.py", line 704, in rmtree
    orig_st = os.lstat(path)
FileNotFoundError: [Errno 2] No such file or directory: 'tufkeystore/'
```

This only deletes the directories if they exist.