### PR TITLE
remove phpcs from running for php8

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -58,6 +58,7 @@ jobs:
         run: composer lint
 
       - name: Run PHPCS
+        if: matrix.php != '8.0'
         run: composer phpcs-ci
 
       - name: Run test suite


### PR DESCRIPTION
I created https://github.com/php-tuf/php-tuf/issues/70 to figure out what is going on with phpcs and php 8. The failure looks like a bug.

I think it is better to stop this check for now so there is no confusion about checks on currently supported version of php passing. The actual phpunit tests will still run on PHP 8 and phpcs will run on all versions for PHP 7 that are in our matrix.