### PR TITLE
Rename RoleDB::createRoleDBFromRootMetadata and KeyDB::createKeyDBFromRootMetadata for clarity

### DIFF
--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -126,7 +126,7 @@ class Updater
         $rootData = RootMetadata::createFromJson($this->durableStorage['root.json']);
 
         $this->roleDB = RoleDB::createFromRootMetadata($rootData);
-        $this->keyDB = KeyDB::createKeyDBFromRootMetadata($rootData);
+        $this->keyDB = KeyDB::createFromRootMetadata($rootData);
 
         $this->updateRoot($rootData);
 
@@ -408,7 +408,7 @@ class Updater
             $this->checkSignatures($nextRoot);
             // Update Role and Key databases to use the new root information.
             $this->roleDB = RoleDB::createFromRootMetadata($nextRoot);
-            $this->keyDB = KeyDB::createKeyDBFromRootMetadata($nextRoot);
+            $this->keyDB = KeyDB::createFromRootMetadata($nextRoot);
             $this->checkSignatures($nextRoot);
             // *TUF-SPEC-v1.0.9 Section 5.1.4
             static::checkRollbackAttack($rootData, $nextRoot, $nextVersion);

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -125,7 +125,7 @@ class Updater
     {
         $rootData = RootMetadata::createFromJson($this->durableStorage['root.json']);
 
-        $this->roleDB = RoleDB::createRoleDBFromRootMetadata($rootData);
+        $this->roleDB = RoleDB::createFromRootMetadata($rootData);
         $this->keyDB = KeyDB::createKeyDBFromRootMetadata($rootData);
 
         $this->updateRoot($rootData);
@@ -407,7 +407,7 @@ class Updater
             // *TUF-SPEC-v1.0.9 Section 5.1.3
             $this->checkSignatures($nextRoot);
             // Update Role and Key databases to use the new root information.
-            $this->roleDB = RoleDB::createRoleDBFromRootMetadata($nextRoot);
+            $this->roleDB = RoleDB::createFromRootMetadata($nextRoot);
             $this->keyDB = KeyDB::createKeyDBFromRootMetadata($nextRoot);
             $this->checkSignatures($nextRoot);
             // *TUF-SPEC-v1.0.9 Section 5.1.4

--- a/src/KeyDB.php
+++ b/src/KeyDB.php
@@ -40,7 +40,7 @@ class KeyDB
      *
      * @see https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#4-document-formats
      */
-    public static function createKeyDBFromRootMetadata(RootMetadata $rootMetadata)
+    public static function createFromRootMetadata(RootMetadata $rootMetadata)
     {
         $db = new self();
 

--- a/src/RoleDB.php
+++ b/src/RoleDB.php
@@ -32,7 +32,7 @@ class RoleDB
      *
      * @see https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#4-document-formats
      */
-    public static function createRoleDBFromRootMetadata(RootMetadata $rootMetadata)
+    public static function createFromRootMetadata(RootMetadata $rootMetadata)
     {
         $db = new self();
         foreach ($rootMetadata->getRoles() as $roleName => $roleInfo) {


### PR DESCRIPTION
It's kind of verbose and redundant for RoleDB::createRoleDBFromRootMetadata() to have the word "RoleDB" in the method name. Same goes for KeyDB::createKeyDBFromRootMetadata().

Let's rename them.