### PR TITLE
\Tuf\Tests\Client\TestRepo::fetchFile interface fix

### DIFF
--- a/src/Client/GuzzleFileFetcher.php
+++ b/src/Client/GuzzleFileFetcher.php
@@ -55,7 +55,7 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
     /**
      * {@inheritdoc}
      */
-    public function fetchFile(string $fileName, int $maxBytes)
+    public function fetchFile(string $fileName, int $maxBytes):string
     {
         try {
             $response = $this->client->request('GET', $fileName);
@@ -79,6 +79,18 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
             return JsonNormalizer::asNormalizedJson($json);
         } else {
             throw new DownloadSizeException("$fileName exceeded $maxBytes bytes");
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchFileIfExists(string $fileName, int $maxBytes):?string
+    {
+        try {
+            return $this->fetchFile($fileName, $maxBytes);
+        } catch (RepoFileNotFound $exception) {
+            return null;
         }
     }
 }

--- a/src/Client/RepoFileFetcherInterface.php
+++ b/src/Client/RepoFileFetcherInterface.php
@@ -2,6 +2,8 @@
 
 namespace Tuf\Client;
 
+use Tuf\Exception\RepoFileNotFound;
+
 /**
  * Defines an interface for fetching repo files.
  */
@@ -26,5 +28,18 @@ interface RepoFileFetcherInterface
      * @throws \Tuf\Exception\DownloadSizeException
      *   Thrown if the file exceeds $maxBytes in size.
      */
-    public function fetchFile(string $fileName, int $maxBytes);
+    public function fetchFile(string $fileName, int $maxBytes):string;
+
+    /**
+     * Gets a file if it exists if it exists in the remote repo.
+     *
+     * @param string $fileName
+     *   The file name to fetch.
+     * @param integer $maxBytes
+     *   The maximum number of bytes to download.
+     *
+     * @return string|null
+     *   The contents of the file or null if it does not exist.
+     */
+    public function fetchFileIfExists(string $fileName, int $maxBytes):?string;
 }

--- a/src/Client/RepoFileFetcherInterface.php
+++ b/src/Client/RepoFileFetcherInterface.php
@@ -31,7 +31,7 @@ interface RepoFileFetcherInterface
     public function fetchFile(string $fileName, int $maxBytes):string;
 
     /**
-     * Gets a file if it exists if it exists in the remote repo.
+     * Gets a file if it exists in the remote repo.
      *
      * @param string $fileName
      *   The file name to fetch.

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -398,7 +398,7 @@ class Updater
         $originalRootData = $rootData;
         // *TUF-SPEC-v1.0.9 Section 5.1.2
         $nextVersion = $rootData->getVersion() + 1;
-        while ($nextRootContents = $this->repoFileFetcher->fetchFile("$nextVersion.root.json", static::MAXIMUM_DOWNLOAD_BYTES)) {
+        while ($nextRootContents = $this->repoFileFetcher->fetchFileIfExists("$nextVersion.root.json", static::MAXIMUM_DOWNLOAD_BYTES)) {
             $rootsDownloaded++;
             if ($rootsDownloaded > static::MAX_ROOT_DOWNLOADS) {
                 throw new \Exception("The maximum number root files have already been dowloaded:" . static::MAX_ROOT_DOWNLOADS);

--- a/tests/Client/TestRepo.php
+++ b/tests/Client/TestRepo.php
@@ -57,7 +57,7 @@ class TestRepo implements RepoFileFetcherInterface
             }
             return $contents;
         } catch (\Exception $exception) {
-            throw new RepoFileNotFound("File $fileName not found.", 0 , $exception);
+            throw new RepoFileNotFound("File $fileName not found.", 0, $exception);
         }
     }
 

--- a/tests/Client/TestRepo.php
+++ b/tests/Client/TestRepo.php
@@ -57,7 +57,7 @@ class TestRepo implements RepoFileFetcherInterface
             }
             return $contents;
         } catch (\Exception $exception) {
-            throw new RepoFileNotFound("File $fileName not found.");
+            throw new RepoFileNotFound("File $fileName not found.", 0 , $exception);
         }
     }
 

--- a/tests/Client/TestRepo.php
+++ b/tests/Client/TestRepo.php
@@ -40,7 +40,7 @@ class TestRepo implements RepoFileFetcherInterface
     /**
      * {@inheritdoc}
      */
-    public function fetchFile(string $fileName, int $maxBytes)
+    public function fetchFile(string $fileName, int $maxBytes):string
     {
         try {
             $contents = file_get_contents(__DIR__ .  "/../../fixtures/{$this->fixturesSet}/tufrepo/metadata/$fileName");
@@ -57,7 +57,19 @@ class TestRepo implements RepoFileFetcherInterface
             }
             return $contents;
         } catch (\Exception $exception) {
-            return false;
+            throw new RepoFileNotFound("File $fileName not found.");
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchFileIfExists(string $fileName, int $maxBytes):?string
+    {
+        try {
+            return $this->fetchFile($fileName, $maxBytes);
+        } catch (RepoFileNotFound $exception) {
+            return null;
         }
     }
 

--- a/tests/Unit/GuzzleFileFetcherTest.php
+++ b/tests/Unit/GuzzleFileFetcherTest.php
@@ -104,9 +104,12 @@ class GuzzleFileFetcherTest extends TestCase
      *
      * @covers ::fetchFile
      */
-    public function testfetchFileError(int $statusCode, string $exceptionClass, ?int $exceptionCode = null, ?int $maxBytes = null): void
+    public function testFetchFileError(int $statusCode, string $exceptionClass, ?int $exceptionCode = null, ?int $maxBytes = null): void
     {
-        $fetcher = $this->getFetcherWithError($statusCode, $exceptionClass, $exceptionCode);
+        $this->mockHandler->append(new Response($statusCode, [], $this->testContent));
+        $this->expectException($exceptionClass);
+        $this->expectExceptionCode($exceptionCode ?? $statusCode);
+        $fetcher = new GuzzleFileFetcher($this->client);
         $fetcher->fetchFile('test.json', $maxBytes ?? strlen($this->testContent));
     }
 
@@ -131,7 +134,10 @@ class GuzzleFileFetcherTest extends TestCase
      */
     public function testFetchFileIfExistsError(int $statusCode, string $exceptionClass, ?int $exceptionCode = null, ?int $maxBytes = null): void
     {
-        $fetcher = $this->getFetcherWithError($statusCode, $exceptionClass, $exceptionCode);
+        $this->mockHandler->append(new Response($statusCode, [], $this->testContent));
+        $this->expectException($exceptionClass);
+        $this->expectExceptionCode($exceptionCode ?? $statusCode);
+        $fetcher = new GuzzleFileFetcher($this->client);
         $fetcher->fetchFileIfExists('test.json', $maxBytes ?? strlen($this->testContent));
     }
 
@@ -165,26 +171,5 @@ class GuzzleFileFetcherTest extends TestCase
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Repo base URI must be HTTPS: http://example.com');
         GuzzleFileFetcher::createFromUri('http://example.com');
-    }
-
-    /**
-     * Gets a fetcher instance that will throw a specified exceptoin.
-     *
-     * @param integer $statusCode
-     *   The response status code.
-     * @param string $exceptionClass
-     *   The expected exception class that will be thrown.
-     * @param integer|null $exceptionCode
-     *   (optional) The expected exception code. Defaults to the status code.
-     *
-     * @return GuzzleFileFetcher
-     *   The fetcher that wll producer an exception.
-     */
-    protected function getFetcherWithError(int $statusCode, string $exceptionClass, ?int $exceptionCode): GuzzleFileFetcher
-    {
-        $this->mockHandler->append(new Response($statusCode, [], $this->testContent));
-        $this->expectException($exceptionClass);
-        $this->expectExceptionCode($exceptionCode ?? $statusCode);
-        return new GuzzleFileFetcher($this->client);
     }
 }

--- a/tests/Unit/GuzzleFileFetcherTest.php
+++ b/tests/Unit/GuzzleFileFetcherTest.php
@@ -148,7 +148,7 @@ class GuzzleFileFetcherTest extends TestCase
         $this->mockHandler->append(new Response(200, [], $this->testContent));
         $this->assertSame($fetcher->fetchFileIfExists('test.json', 256), $this->testContent);
         $this->mockHandler->append(new Response(404, []));
-        $this->assertSame($fetcher->fetchFileIfExists('test.json', 256), null);
+        $this->assertNull($fetcher->fetchFileIfExists('test.json', 256));
     }
 
     /**


### PR DESCRIPTION
\Tuf\Tests\Client\TestRepo::fetchFile incorrectly returned a false when no file when interface says to throw exception

`\Tuf\Client\Updater::updateRoot()` was depending on the this broken behavior so a new method `\Tuf\Client\RepoFileFetcherInterface::fetchFileIfExists()` was added to make this cleaner.

This fix was in #80  but it is really unrelated just discovered there