### PR TITLE
Add testing for file not file exception

### DIFF
--- a/tests/Client/TestRepo.php
+++ b/tests/Client/TestRepo.php
@@ -5,26 +5,21 @@ namespace Tuf\Tests\Client;
 use Tuf\Client\RepoFileFetcherInterface;
 use Tuf\Exception\RepoFileNotFound;
 use Tuf\JsonNormalizer;
+use Tuf\Tests\TestHelpers\UtilsTrait;
 
 /**
  * Defines an implementation of RepoFileFetcherInterface to use with test fixtures.
  */
 class TestRepo implements RepoFileFetcherInterface
 {
+    use UtilsTrait;
 
     /**
-     * The fixtures set to use.
-     *
-     * @var string
-     */
-    protected $fixturesSet;
-
-    /**
-     * File names for files that should fail signature checks.
+     * An array of repo file contents keyed by file name.
      *
      * @var string[]
      */
-    protected $failSignatureFiles = [];
+    private $repoFilesContents = [];
 
     /**
      * TestRepo constructor.
@@ -34,7 +29,12 @@ class TestRepo implements RepoFileFetcherInterface
      */
     public function __construct(string $fixturesSet)
     {
-        $this->fixturesSet = $fixturesSet;
+        // Store all the repo files locally so they can be easily altered.
+        // @see self::setRepoFileNestedValue()
+        $repoFiles = glob(static::getFixturesRealPath($fixturesSet, '/tufrepo/metadata') . '/*.json');
+        foreach ($repoFiles as $repoFile) {
+            $this->repoFilesContents[basename($repoFile)] = file_get_contents($repoFile);
+        }
     }
 
     /**
@@ -42,23 +42,10 @@ class TestRepo implements RepoFileFetcherInterface
      */
     public function fetchFile(string $fileName, int $maxBytes):string
     {
-        try {
-            $contents = file_get_contents(__DIR__ .  "/../../fixtures/{$this->fixturesSet}/tufrepo/metadata/$fileName");
-            if ($contents === false) {
-                throw new RepoFileNotFound("File $fileName not found.");
-            }
-            // Alter the signed portion of the json contents to trigger an
-            // exception.
-            // @see \Tuf\Client\Updater::checkSignatures()
-            if (in_array($fileName, $this->failSignatureFiles)) {
-                $json = json_decode($contents);
-                $json->signed->extra_test_value = 'value';
-                $contents = json_encode($json);
-            }
-            return $contents;
-        } catch (\Exception $exception) {
-            throw new RepoFileNotFound("File $fileName not found.", 0, $exception);
+        if (empty($this->repoFilesContents[$fileName])) {
+            throw new RepoFileNotFound("File $fileName not found.");
         }
+        return $this->repoFilesContents[$fileName];
     }
 
     /**
@@ -74,15 +61,34 @@ class TestRepo implements RepoFileFetcherInterface
     }
 
     /**
-     * Sets the file for which a signature fail should be triggered.
+     * Sets a nested value in a repo file.
      *
-     * @param array $fileNames
-     *   The file names for which a signature fail should be triggered.
+     * @param string $fileName
+     *   The name of the file to change.
+     * @param array $keys
+     *   The nested array keys of the item.
+     * @param mixed $newValue
+     *   The new value to set.
      *
      * @return void
      */
-    public function setFilesToFailSignature(array $fileNames)
+    public function setRepoFileNestedValue(string $fileName, array $keys = ['signed', 'extra_test_value'], $newValue = 'new value'): void
     {
-        $this->failSignatureFiles = $fileNames;
+        $json = json_decode($this->repoFilesContents[$fileName], true);
+        static::nestedChange($keys, $json, $newValue);
+        $this->repoFilesContents[$fileName] = JsonNormalizer::asNormalizedJson($json);
+    }
+
+    /**
+     * Removes a file from the repo.
+     *
+     * @param string $fileName
+     *   The name of the file to remove.
+     *
+     * @return void
+     */
+    public function removeRepoFile(string $fileName):void
+    {
+        unset($this->repoFilesContents[$fileName]);
     }
 }

--- a/tests/Metadata/MetaDataBaseTest.php
+++ b/tests/Metadata/MetaDataBaseTest.php
@@ -287,28 +287,6 @@ abstract class MetaDataBaseTest extends TestCase
     }
 
     /**
-     * Change a nested array element.
-     *
-     * @param array $keys
-     *   Ordered keys to the value to set.
-     * @param array $data
-     *   The array to modify.
-     * @param mixed $newValue
-     *   The new value to set.
-     *
-     * @return void
-     */
-    protected function nestedChange(array $keys, array &$data, $newValue) : void
-    {
-        $key = array_shift($keys);
-        if ($keys) {
-            $this->nestedChange($keys, $data[$key], $newValue);
-        } else {
-            $data[$key] = $newValue;
-        }
-    }
-
-    /**
      * Dataprovider for testExpires().
      *
      * @return array

--- a/tests/TestHelpers/UtilsTrait.php
+++ b/tests/TestHelpers/UtilsTrait.php
@@ -53,7 +53,9 @@ trait UtilsTrait
                 $key = (string) $arguments[$useArgumentNumber];
             } else {
                 foreach ($arguments as $argument) {
-                    $key .= '-' . (string) $argument;
+                    if (is_numeric($argument) || is_string($argument)) {
+                        $key .= '-' . (string) $argument;
+                    }
                 }
             }
 
@@ -63,5 +65,27 @@ trait UtilsTrait
             $newData[$key] = $arguments;
         }
         return $newData;
+    }
+
+    /**
+     * Change a nested array element.
+     *
+     * @param array $keys
+     *   Ordered keys to the value to set.
+     * @param array $data
+     *   The array to modify.
+     * @param mixed $newValue
+     *   The new value to set.
+     *
+     * @return void
+     */
+    protected function nestedChange(array $keys, array &$data, $newValue) : void
+    {
+        $key = array_shift($keys);
+        if ($keys) {
+            $this->nestedChange($keys, $data[$key], $newValue);
+        } else {
+            $data[$key] = $newValue;
+        }
     }
 }


### PR DESCRIPTION
#90 fixed the TestRepo class to thrown exception instead of returning FALSE on a file not found. This was originally in #80 but we split it off because it was unrelated. But we forgot to pull out all the test coverage for this fix that was in #80 

This is the test coverage. It will also make #80 even smaller