### PR TITLE
KeyDB::getKey() will return metadata with unused sha512 'keyid' array key for both 256 and 512 key ids.

### DIFF
--- a/src/KeyDB.php
+++ b/src/KeyDB.php
@@ -46,15 +46,8 @@ class KeyDB
         $db = new self();
 
         foreach ($rootMetadata->getKeys() as $keyMeta) {
-            if (! in_array($keyMeta['keytype'], self::getSupportedKeyTypes(), true)) {
-                // @todo Convert this to a log line as per Python.
-                throw new \Exception("Root metadata file contains an unsupported key type: \"${keyMeta['keytype']}\"");
-            }
-            // One key ID for each $keyMeta['keyid_hash_algorithms'].
-            $computedKeyIds = self::computeKeyIds($keyMeta);
-            foreach ($computedKeyIds as $keyId) {
-                $db->addKey($keyId, $keyMeta);
-            }
+            $db->addKey($keyMeta);
+
         }
 
         return $db;
@@ -138,9 +131,17 @@ class KeyDB
      *
      * @todo https://github.com/php-tuf/php-tuf/issues/56
      */
-    private function addKey(string $keyId, \ArrayAccess $keyMeta)
+    private function addKey(\ArrayAccess $keyMeta)
     {
-        $this->keys[$keyId] = $keyMeta;
+        if (! in_array($keyMeta['keytype'], self::getSupportedKeyTypes(), true)) {
+            // @todo Convert this to a log line as per Python.
+            throw new \Exception("Root metadata file contains an unsupported key type: \"${keyMeta['keytype']}\"");
+        }
+        // One key ID for each $keyMeta['keyid_hash_algorithms'].
+        $computedKeyIds = self::computeKeyIds($keyMeta);
+        foreach ($computedKeyIds as $keyId) {
+            $this->keys[$keyId] = $keyMeta;
+        }
     }
 
     /**

--- a/src/KeyDB.php
+++ b/src/KeyDB.php
@@ -46,7 +46,7 @@ class KeyDB
         $db = new self();
 
         foreach ($rootMetadata->getKeys() as $keyMeta) {
-            $db->addKey($keyMeta);
+            $db->addKeyMetadata($keyMeta);
 
         }
 
@@ -115,8 +115,6 @@ class KeyDB
     /**
      * Adds key metadata to the key database while avoiding duplicates.
      *
-     * @param string $keyId
-     *     The key id.
      * @param \ArrayAccess $keyMeta
      *     An associative array of key metadata, including:
      *     - keytype: The public key signature system, e.g. 'ed25519'.
@@ -131,7 +129,7 @@ class KeyDB
      *
      * @todo https://github.com/php-tuf/php-tuf/issues/56
      */
-    private function addKey(\ArrayAccess $keyMeta)
+    private function addKeyMetadata(\ArrayAccess $keyMeta)
     {
         if (! in_array($keyMeta['keytype'], self::getSupportedKeyTypes(), true)) {
             // @todo Convert this to a log line as per Python.

--- a/src/KeyDB.php
+++ b/src/KeyDB.php
@@ -47,7 +47,6 @@ class KeyDB
 
         foreach ($rootMetadata->getKeys() as $keyMeta) {
             $db->addKeyMetadata($keyMeta);
-
         }
 
         return $db;

--- a/src/KeyDB.php
+++ b/src/KeyDB.php
@@ -46,7 +46,7 @@ class KeyDB
         $db = new self();
 
         foreach ($rootMetadata->getKeys() as $keyMeta) {
-            $db->addKeyMetadata($keyMeta);
+            $db->addKey($keyMeta);
         }
 
         return $db;
@@ -128,7 +128,7 @@ class KeyDB
      *
      * @todo https://github.com/php-tuf/php-tuf/issues/56
      */
-    private function addKeyMetadata(\ArrayAccess $keyMeta)
+    private function addKey(\ArrayAccess $keyMeta)
     {
         if (! in_array($keyMeta['keytype'], self::getSupportedKeyTypes(), true)) {
             // @todo Convert this to a log line as per Python.

--- a/tests/KeyDBTest.php
+++ b/tests/KeyDBTest.php
@@ -45,8 +45,7 @@ class KeyDBTest extends TestCase
         $key512 = $keyDb->getKey($keyId512);
         self::assertEquals($expectedKeyDataObject, $key256);
         self::assertEquals($expectedKeyDataObject, $key512);
-        // Ensure that changing a value in the key does not affect the internal
-        // state of the KeyDB object.
+        // Ensure that changing a value in the key does not affect the internal state of the KeyDB object.
         $key256['keyval']['new_key'] = 'new_value';
         $key512['keyval']['new_key'] = 'new_value';
         self::assertEquals($expectedKeyDataObject, $keyDb->getKey($keyId256));

--- a/tests/KeyDBTest.php
+++ b/tests/KeyDBTest.php
@@ -4,28 +4,52 @@ namespace Tuf\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Tuf\KeyDB;
+use Tuf\Metadata\RootMetadata;
+use Tuf\Tests\TestHelpers\UtilsTrait;
 
 /**
- * Tests KeyDB functionality.
+ * @coversDefaultClass \Tuf\KeyDB
  */
 class KeyDBTest extends TestCase
 {
+    use UtilsTrait;
     /**
-     * Tests that computed key IDs match expected values in the repository.
-     *
-     * @dataProvider computeKeyIdProvider
-     *
-     * @param mixed[] $metadata
-     *     The metadata for which to compute keys.
-     * @param string[] $expected
-     *     The expected key values.
+     * @covers ::createFromRootMetadata
      *
      * @return void
      */
-    public function testComputeKeyId(array $metadata, array $expected) : void
+    public function testCreateFromRootMetadata():void
     {
-        $actual = KeyDB::computeKeyIds(new \ArrayObject($metadata));
-        $this->assertEquals($expected, $actual);
+        $rootJsonPath = static::getFixturesRealPath('TUFTestFixtureDelegated',
+          'tufclient/tufrepo/metadata/current/3.root.json', false);
+        $rootMetadata = RootMetadata::createFromJson(file_get_contents($rootJsonPath));
+        self::assertInstanceOf(RootMetadata::class, $rootMetadata);
+        $keyDb = KeyDB::createFromRootMetadata($rootMetadata);
+        self::assertInstanceOf(KeyDB::class, $keyDb);
+        $keyId256 = '77dfdca206c0fe1b8e55d67d21dd0e195a0998a9d2b56c6d3ee8f68d04c21e93';
+        $keyId512 = 'ae0bd43afa380e413c34ca6a51092d9b0bb81e8e4913dfeb137bb1b7f23fa6cb7f32a104b8e13eab438cd9198c09a5115753d9315c23cf3230093424e19be694';
+        $expectedKeyData = [
+          'keyid_hash_algorithms' => [
+            'sha256',
+            'sha512',
+          ],
+          'keytype' => 'ed25519',
+          'keyval' => new \ArrayObject([
+            'public' => '6400d770c7c1bce4b3d59ce0079ed686e843b6500bbea77d869a1ae7df4565a1',
+          ]),
+          'scheme' => 'ed25519',
+        ];
+        $expectedKeyDataObject = new \ArrayObject($expectedKeyData);
+        $key256 = $keyDb->getKey($keyId256);
+        $key512 = $keyDb->getKey($keyId512);
+        self::assertEquals($expectedKeyDataObject, $key256);
+        self::assertEquals($expectedKeyDataObject, $key512);
+        // Ensure that changing a value in the key does not affect the internal
+        // state of the KeyDB object.
+        $key256['keyval']['new_key'] = 'new_value';
+        $key512['keyval']['new_key'] = 'new_value';
+        self::assertEquals($expectedKeyDataObject, $keyDb->getKey($keyId256));
+        self::assertEquals($expectedKeyDataObject, $keyDb->getKey($keyId512));
     }
 
     /**

--- a/tests/KeyDBTest.php
+++ b/tests/KeyDBTest.php
@@ -20,8 +20,11 @@ class KeyDBTest extends TestCase
      */
     public function testCreateFromRootMetadata():void
     {
-        $rootJsonPath = static::getFixturesRealPath('TUFTestFixtureDelegated',
-          'tufclient/tufrepo/metadata/current/3.root.json', false);
+        $rootJsonPath = static::getFixturesRealPath(
+            'TUFTestFixtureDelegated',
+            'tufclient/tufrepo/metadata/current/3.root.json',
+            false
+        );
         $rootMetadata = RootMetadata::createFromJson(file_get_contents($rootJsonPath));
         self::assertInstanceOf(RootMetadata::class, $rootMetadata);
         $keyDb = KeyDB::createFromRootMetadata($rootMetadata);
@@ -29,15 +32,13 @@ class KeyDBTest extends TestCase
         $keyId256 = '77dfdca206c0fe1b8e55d67d21dd0e195a0998a9d2b56c6d3ee8f68d04c21e93';
         $keyId512 = 'ae0bd43afa380e413c34ca6a51092d9b0bb81e8e4913dfeb137bb1b7f23fa6cb7f32a104b8e13eab438cd9198c09a5115753d9315c23cf3230093424e19be694';
         $expectedKeyData = [
-          'keyid_hash_algorithms' => [
-            'sha256',
-            'sha512',
-          ],
-          'keytype' => 'ed25519',
-          'keyval' => new \ArrayObject([
-            'public' => '6400d770c7c1bce4b3d59ce0079ed686e843b6500bbea77d869a1ae7df4565a1',
-          ]),
-          'scheme' => 'ed25519',
+            'keyid_hash_algorithms' => [
+                'sha256',
+                'sha512',
+            ],
+            'keytype' => 'ed25519',
+            'keyval' => new \ArrayObject(['public' => '6400d770c7c1bce4b3d59ce0079ed686e843b6500bbea77d869a1ae7df4565a1']),
+            'scheme' => 'ed25519',
         ];
         $expectedKeyDataObject = new \ArrayObject($expectedKeyData);
         $key256 = $keyDb->getKey($keyId256);
@@ -50,31 +51,5 @@ class KeyDBTest extends TestCase
         $key512['keyval']['new_key'] = 'new_value';
         self::assertEquals($expectedKeyDataObject, $keyDb->getKey($keyId256));
         self::assertEquals($expectedKeyDataObject, $keyDb->getKey($keyId512));
-    }
-
-    /**
-     * Data provider for testComputeKeyId().
-     *
-     * @return array[][]
-     *     An associative array of test cases, each containing:
-     *     - metadata: The key metadata to check.
-     *     - expected: The expected keys from the repository.
-     */
-    public function computeKeyIdProvider() : array
-    {
-        return [
-            'case 1' => [
-                'metadata' => [
-                    'keyid_hash_algorithms' => ['sha256', 'sha512'],
-                    'keytype' => 'ed25519',
-                    'keyval' => ['public' => 'edcd0a32a07dce33f7c7873aaffbff36d20ea30787574ead335eefd337e4dacd'],
-                    'scheme' => 'ed25519',
-                ],
-                'expected' => [
-                    '59a4df8af818e9ed7abe0764c0b47b4240952aa0d179b5b78346c470ac30278d',
-                    '594e8b4bdafc33fd87e9d03a95be13a6dc93a836086614fd421116d829af68d8f0110ae93e3dde9a246897fd85171455ea53191bb96cf9e589ba047d057dbd66',
-                ],
-            ],
-        ];
     }
 }


### PR DESCRIPTION
Work @bircher and @ZeiP at DrupalCon Europe 2020 contribution day.

Originally we were going reroll #49 but we found this bug in the process. 

It was probably caused when we switched from using array to ArrayObjects because they are passed by reference