### PR TITLE
Change all URLs to spec to version 1.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 PHP-TUF is a PHP implementation of [The Update Framework 
 (TUF)](https://theupdateframework.io/) to provide signing and verification for 
 secure PHP application updates. [Read the TUF 
-specification](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md) 
+specification](https://github.com/theupdateframework/specification/blob/v1.0.9/tuf-spec.md) 
 for more information on how TUF is intended to work and the security it
 provides.
 
@@ -115,5 +115,5 @@ dependency information](DEPENDENCIES.md).
   * [Code Documentation: Main Index](https://github.com/theupdateframework/tuf/blob/develop/tuf/README.md)
   * [CLI](https://github.com/theupdateframework/tuf/blob/develop/docs/CLI.md)
   * [Python API Readme](https://github.com/theupdateframework/tuf/blob/develop/tuf/client/README.md)
-* [TUF Specification](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md)
+* [TUF Specification v1.0.9](https://github.com/theupdateframework/specification/blob/v1.0.9/tuf-spec.md)
 * [PIP + TUF Integration](https://www.python.org/dev/peps/pep-0458/)

--- a/src/KeyDB.php
+++ b/src/KeyDB.php
@@ -39,7 +39,7 @@ class KeyDB
      * @throws \Exception
      *   Thrown if an unsupported key type exists in the metadata.
      *
-     * @see https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.9/tuf-spec.md#4-document-formats
      */
     public static function createFromRootMetadata(RootMetadata $rootMetadata)
     {
@@ -82,7 +82,7 @@ class KeyDB
      *     There is one entry for each hashing algorithm specified in the
      *     'keyid_hash_algorithms' child array.
      *
-     * @see https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.9/tuf-spec.md#4-document-formats
      *
      * @todo https://github.com/php-tuf/php-tuf/issues/56
      */
@@ -124,7 +124,7 @@ class KeyDB
      *
      * @return void
      *
-     * @see https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.9/tuf-spec.md#4-document-formats
      *
      * @todo https://github.com/php-tuf/php-tuf/issues/56
      */
@@ -154,7 +154,7 @@ class KeyDB
      * @throws \Exception
      *     Thrown if the key ID is not found in the keydb database.
      *
-     * @see https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.9/tuf-spec.md#4-document-formats
      */
     public function getKey(string $keyId):\ArrayObject
     {

--- a/src/RoleDB.php
+++ b/src/RoleDB.php
@@ -30,7 +30,7 @@ class RoleDB
      * @throws \Exception
      *     Thrown if a threshold value in the metadata is not valid.
      *
-     * @see https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.9/tuf-spec.md#4-document-formats
      */
     public static function createFromRootMetadata(RootMetadata $rootMetadata)
     {
@@ -56,7 +56,7 @@ class RoleDB
                 //     versa and are in a separate part of the document. Review
                 //     this once https://github.com/php-tuf/php-tuf/issues/52
                 //     is resolved.
-                // @see https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#4-document-formats
+                // @see https://github.com/theupdateframework/specification/blob/v1.0.9/tuf-spec.md#4-document-formats
                 $roleInfo['delegations'] = ['keys' => [], 'roles' => []];
             }
             $roleInfo['paths'] = [];
@@ -92,7 +92,7 @@ class RoleDB
      * @throws \Exception
      *     Thrown if the role already exists.
      *
-     * @see https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.9/tuf-spec.md#4-document-formats
      *
      * @todo Provide more complete documentation of the structure once
      *     delgation is implemented and fixtures are regenerated. Issues:
@@ -135,7 +135,7 @@ class RoleDB
      * @throws \Exception
      *     Thrown if the role does not exist.
      *
-     * @see https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.9/tuf-spec.md#4-document-formats
      */
     public function getRoleInfo(string $roleName)
     {


### PR DESCRIPTION
In most code comments which refer to the TUF spec we specify version 1.0.9. like 
`// TUF-SPEC-v1.0.9 Section 5.1.11.`

But in the readme and other links in comments we link to `master`. 

This changes all the links to `v1.0.9`