### PR TITLE
Throw metadata validation exception on Unsupported fields

### DIFF
--- a/src/Constraints/Collection.php
+++ b/src/Constraints/Collection.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tuf\Constraints;
+
+use Symfony\Component\Validator\Constraints\Collection as SymfonyCollection;
+
+/**
+ * Custom constraint that extends Symfony's Collection constraint to add 'excludedFields'.
+ */
+class Collection extends SymfonyCollection
+{
+
+    /**
+     * @var array
+     */
+    public $unsupportedFields = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($options = null)
+    {
+        if (isset($options['excludedFields']) && !isset($options['fields'])) {
+            throw new \InvalidArgumentException('If "excludedFields" is set "fields" must also be set.');
+        }
+        parent::__construct($options);
+    }
+}

--- a/src/Constraints/Collection.php
+++ b/src/Constraints/Collection.php
@@ -14,15 +14,4 @@ class Collection extends SymfonyCollection
      * @var array
      */
     public $unsupportedFields = [];
-
-    /**
-     * {@inheritdoc}
-     */
-    public function __construct($options = null)
-    {
-        if (isset($options['excludedFields']) && !isset($options['fields'])) {
-            throw new \InvalidArgumentException('If "excludedFields" is set "fields" must also be set.');
-        }
-        parent::__construct($options);
-    }
 }

--- a/src/Constraints/CollectionValidator.php
+++ b/src/Constraints/CollectionValidator.php
@@ -14,20 +14,17 @@ class CollectionValidator extends SymfonyCollectionValidator
      */
     public function validate($value, Constraint $constraint)
     {
-        if (!empty($constraint->unsupportedFields)) {
-            foreach ($constraint->unsupportedFields as $unsupportedField) {
-                $existsInArray = \is_array($value) && \array_key_exists($unsupportedField, $value);
-                $existsInArrayAccess = $value instanceof \ArrayAccess && $value->offsetExists($unsupportedField);
-                if ($existsInArray || $existsInArrayAccess) {
-                    $this->context->buildViolation('This field is not supported.')
-                      ->atPath('['.$unsupportedField.']')
-                      ->setInvalidValue(null)
-                      ->setCode(Collection::MISSING_FIELD_ERROR)
-                      ->addViolation();
-                }
+        foreach ($constraint->unsupportedFields as $unsupportedField) {
+            $existsInArray = \is_array($value) && \array_key_exists($unsupportedField, $value);
+            $existsInArrayAccess = $value instanceof \ArrayAccess && $value->offsetExists($unsupportedField);
+            if ($existsInArray || $existsInArrayAccess) {
+                $this->context->buildViolation('This field is not supported.')
+                  ->atPath("[$unsupportedField]")
+                  ->setInvalidValue(null)
+                  ->setCode(Collection::MISSING_FIELD_ERROR)
+                  ->addViolation();
             }
         }
-
         parent::validate($value, $constraint);
     }
 }

--- a/src/Constraints/CollectionValidator.php
+++ b/src/Constraints/CollectionValidator.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tuf\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Collection;
+use Symfony\Component\Validator\Constraints\CollectionValidator as SymfonyCollectionValidator;
+
+class CollectionValidator extends SymfonyCollectionValidator
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!empty($constraint->unsupportedFields)) {
+            foreach ($constraint->unsupportedFields as $unsupportedField) {
+                $existsInArray = \is_array($value) && \array_key_exists($unsupportedField, $value);
+                $existsInArrayAccess = $value instanceof \ArrayAccess && $value->offsetExists($unsupportedField);
+                if ($existsInArray || $existsInArrayAccess) {
+                    $this->context->buildViolation('This field is not supported.')
+                      ->atPath('['.$unsupportedField.']')
+                      ->setInvalidValue(null)
+                      ->setCode(Collection::MISSING_FIELD_ERROR)
+                      ->addViolation();
+                }
+            }
+        }
+
+        parent::validate($value, $constraint);
+    }
+}

--- a/src/Metadata/SnapshotMetadata.php
+++ b/src/Metadata/SnapshotMetadata.php
@@ -30,6 +30,9 @@ class SnapshotMetadata extends MetadataBase
                 new Collection(
                     [
                         'fields' => static::getVersionConstraints(),
+                        // These fields are mentioned in the specification as optional but the Python library does not
+                        // adding these fields. Since we use the Python library for our fixtures we cannot create test
+                        // fixtures that have these fields specified.
                         'unsupportedFields' => ['length', 'hashes'],
                         'allowExtraFields' => true,
                     ]

--- a/src/Metadata/SnapshotMetadata.php
+++ b/src/Metadata/SnapshotMetadata.php
@@ -28,11 +28,11 @@ class SnapshotMetadata extends MetadataBase
             new Count(['min' => 1]),
             new All([
                 new Collection(
-                  [
-                    'fields' => static::getVersionConstraints(),
-                      'excludedFields' => ['length', 'hashes'],
-                      'allowExtraFields' => true,
-                   ],
+                    [
+                        'fields' => static::getVersionConstraints(),
+                        'unsupportedFields' => ['length', 'hashes'],
+                        'allowExtraFields' => true,
+                    ]
                 ),
             ]),
         ]);

--- a/src/Metadata/SnapshotMetadata.php
+++ b/src/Metadata/SnapshotMetadata.php
@@ -31,7 +31,7 @@ class SnapshotMetadata extends MetadataBase
                     [
                         'fields' => static::getVersionConstraints(),
                         // These fields are mentioned in the specification as optional but the Python library does not
-                        // adding these fields. Since we use the Python library for our fixtures we cannot create test
+                        // add these fields. Since we use the Python library for our fixtures we cannot create test
                         // fixtures that have these fields specified.
                         'unsupportedFields' => ['length', 'hashes'],
                         'allowExtraFields' => true,

--- a/src/Metadata/SnapshotMetadata.php
+++ b/src/Metadata/SnapshotMetadata.php
@@ -31,26 +31,12 @@ class SnapshotMetadata extends MetadataBase
             new All([
                 new Collection(
                     [
-                      'fields' => static::getVersionConstraints(),
+                        'fields' => static::getVersionConstraints(),
                         'allowExtraFields' => false,
                     ]
-
                 ),
             ]),
         ]);
         return $options;
-    }
-    protected static function validateMetaData(\ArrayObject $metadata): void
-    {
-        parent::validateMetaData($metadata);
-        /** @var \ArrayAccess $signed */
-        $signed = $metadata['signed'];
-        if (isset($signed['meta'])) {
-            foreach ($signed['meta'] as $fileName => $fileInfo) {
-                if (isset($fileInfo['length'])) {
-                    throw new MetadataException("The length attribute is not supported for ['meta']['$fileName'] in snapshot metadata");
-                }
-            }
-        }
     }
 }

--- a/src/Metadata/SnapshotMetadata.php
+++ b/src/Metadata/SnapshotMetadata.php
@@ -3,12 +3,10 @@
 namespace Tuf\Metadata;
 
 use Symfony\Component\Validator\Constraints\All;
-use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\Count;
-use Symfony\Component\Validator\Constraints\Optional;
 use Symfony\Component\Validator\Constraints\Required;
 use Symfony\Component\Validator\Constraints\Type;
-use Tuf\Exception\MetadataException;
+use Tuf\Constraints\Collection;
 
 class SnapshotMetadata extends MetadataBase
 {
@@ -30,10 +28,11 @@ class SnapshotMetadata extends MetadataBase
             new Count(['min' => 1]),
             new All([
                 new Collection(
-                    [
-                        'fields' => static::getVersionConstraints(),
-                        'allowExtraFields' => false,
-                    ]
+                  [
+                    'fields' => static::getVersionConstraints(),
+                      'excludedFields' => ['length', 'hashes'],
+                      'allowExtraFields' => true,
+                   ],
                 ),
             ]),
         ]);

--- a/tests/Metadata/SnapshotMetadataTest.php
+++ b/tests/Metadata/SnapshotMetadataTest.php
@@ -55,7 +55,8 @@ class SnapshotMetadataTest extends MetaDataBaseTest
      *
      * @todo Change this more generic `testUnsupportedfields()` in base class.
      */
-    public function testUnsupportedLength() {
+    public function testUnsupportedLength()
+    {
         $metadata = json_decode($this->localRepo[$this->validJson], true);
         $metadata['signed']['meta']['targets.json']['length'] = 1;
         $expectedMessage = preg_quote("Object(ArrayObject)[signed][meta][targets.json][length]", '/');

--- a/tests/Metadata/SnapshotMetadataTest.php
+++ b/tests/Metadata/SnapshotMetadataTest.php
@@ -59,6 +59,8 @@ class SnapshotMetadataTest extends MetaDataBaseTest
      *   The field value to set.
      *
      * @dataProvider providerUnsupportedFields
+     *
+     * @return void
      */
     public function testUnsupportedFields(array $unsupportedField, $fieldValue):void
     {
@@ -76,12 +78,13 @@ class SnapshotMetadataTest extends MetaDataBaseTest
      * Data provider for testUnsupportedFields().
      *
      * @return array[]
+     *  The test cases.
      */
     public function providerUnsupportedFields():array
     {
         return [
-          'length' => [['signed', 'meta', 'targets.json', 'length'], 1],
-         'hashes' => [['signed', 'meta', 'targets.json', 'hashes'], []],
+            'length' => [['signed', 'meta', 'targets.json', 'length'], 1],
+            'hashes' => [['signed', 'meta', 'targets.json', 'hashes'], []],
         ];
     }
 }

--- a/tests/Metadata/SnapshotMetadataTest.php
+++ b/tests/Metadata/SnapshotMetadataTest.php
@@ -2,6 +2,7 @@
 
 namespace Tuf\Tests\Metadata;
 
+use Tuf\Exception\MetadataException;
 use Tuf\Metadata\MetadataBase;
 use Tuf\Metadata\SnapshotMetadata;
 
@@ -50,15 +51,17 @@ class SnapshotMetadataTest extends MetaDataBaseTest
     }
 
     /**
-     * {@inheritdoc}
+     * @throws \Tuf\Exception\MetadataException
+     *
+     * @todo Change this more generic `testUnsupportedfields()` in base class.
      */
-    public function providerOptionalFields()
-    {
-        $data = parent::providerOptionalFields();
-        $data[] = [
-            'signed:meta:targets.json:length',
-            789,
-        ];
-        return static::getKeyedArray($data);
+    public function testUnsupportedLength() {
+        $metadata = json_decode($this->localRepo[$this->validJson], true);
+        $metadata['signed']['meta']['targets.json']['length'] = 1;
+        $expectedMessage = preg_quote("Object(ArrayObject)[signed][meta][targets.json][length]", '/');
+        $expectedMessage .= ".*This field was not expected.";
+        $this->expectException(MetadataException::class);
+        $this->expectExceptionMessageMatches("/$expectedMessage/s");
+        static::callCreateFromJson(json_encode($metadata));
     }
 }


### PR DESCRIPTION
This may not necessary but it seems like there are some optional fields that the Python lib might not support creating.