### PR TITLE
Allow multiple major versions of Symfony and Guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         "php": ">=7.2.5",
         "ext-json": "*",
         "paragonie/sodium_compat": "^1.13",
-        "symfony/validator": "^5.1",
-        "guzzlehttp/guzzle": "^7.2",
+        "symfony/validator": "^4.4 || ^5.1",
+        "guzzlehttp/guzzle": "^6.5 || ^7.2",
         "myclabs/deep-copy": "^1.10.2"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         "php": ">=7.2.5",
         "ext-json": "*",
         "paragonie/sodium_compat": "^1.13",
-        "guzzlehttp/guzzle": "^5.3 || ^6.5 || ^7.2",
         "symfony/validator": "^4.4 || ^5.1",
+        "guzzlehttp/guzzle": "^6.5 || ^7.2",
         "myclabs/deep-copy": "^1.10.2"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         "php": ">=7.2.5",
         "ext-json": "*",
         "paragonie/sodium_compat": "^1.13",
-        "symfony/validator": "^4.4",
-        "guzzlehttp/guzzle": "^6.5",
+        "symfony/validator": "^4.4 || ^5.1",
+        "guzzlehttp/guzzle": "^6.5 || ^7.2",
         "myclabs/deep-copy": "^1.10.2"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         "php": ">=7.2.5",
         "ext-json": "*",
         "paragonie/sodium_compat": "^1.13",
-        "symfony/validator": "^3.4 || ^4.4 || ^5.1",
         "guzzlehttp/guzzle": "^5.3 || ^6.5 || ^7.2",
+        "symfony/validator": "^4.4 || ^5.1",
         "myclabs/deep-copy": "^1.10.2"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-json": "*",
         "paragonie/sodium_compat": "^1.13",
         "symfony/validator": "^3.4 || ^4.4 || ^5.1",
-        "guzzlehttp/guzzle": "^6.5 || ^7.2",
+        "guzzlehttp/guzzle": "^5.3 || ^6.5 || ^7.2",
         "myclabs/deep-copy": "^1.10.2"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=7.2.5",
         "ext-json": "*",
         "paragonie/sodium_compat": "^1.13",
-        "symfony/validator": "^4.4 || ^5.1",
+        "symfony/validator": "^4.4 || ^5",
         "guzzlehttp/guzzle": "^6.5 || ^7.2",
         "myclabs/deep-copy": "^1.10.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         "php": ">=7.2.5",
         "ext-json": "*",
         "paragonie/sodium_compat": "^1.13",
-        "symfony/validator": "^4.4 || ^5.1",
-        "guzzlehttp/guzzle": "^6.5 || ^7.2",
+        "symfony/validator": "^4.4",
+        "guzzlehttp/guzzle": "^6.5",
         "myclabs/deep-copy": "^1.10.2"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=7.2.5",
         "ext-json": "*",
         "paragonie/sodium_compat": "^1.13",
-        "symfony/validator": "^4.4 || ^5.1",
+        "symfony/validator": "^3.4 || ^4.4 || ^5.1",
         "guzzlehttp/guzzle": "^6.5 || ^7.2",
         "myclabs/deep-copy": "^1.10.2"
     },


### PR DESCRIPTION
Right now, this package cannot be installed alongside Drupal core 8 or 9, since they require versions of Guzzle and Symfony that we don't declare compatibility with. I'd _guess_ that we are not using any APIs which changed between Guzzle 6 and 7 and Symfony 4 and 5 (although I'm by no means the best informed about that), so we should probably allow core-compatible versions of those packages.