### PR TITLE
GuzzleFileFetcher inadvertently modifies the fetched JSON

### DIFF
--- a/src/Client/GuzzleFileFetcher.php
+++ b/src/Client/GuzzleFileFetcher.php
@@ -7,7 +7,6 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ClientException;
 use Tuf\Exception\DownloadSizeException;
 use Tuf\Exception\RepoFileNotFound;
-use Tuf\JsonNormalizer;
 
 /**
  * Defines a file fetcher that uses Guzzle to read a file over HTTPS.
@@ -75,8 +74,7 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
         // If we reached the end of the stream, we didn't exceed the maximum
         // number of bytes.
         if ($body->eof() === true) {
-            $json = json_decode($contents, true);
-            return JsonNormalizer::asNormalizedJson($json);
+            return $contents;
         } else {
             throw new DownloadSizeException("$fileName exceeded $maxBytes bytes");
         }

--- a/tests/Unit/GuzzleFileFetcherTest.php
+++ b/tests/Unit/GuzzleFileFetcherTest.php
@@ -41,10 +41,13 @@ class GuzzleFileFetcherTest extends TestCase
      * @var string
      */
     private $testContent = <<<END
-["oolong",
-  "assam",
-"matcha",
-"herbal"]
+{
+  "tea": ["oolong",
+     "assam",   "matcha",
+"herbal"],
+  "coffee" ["Arabica", "Catuai",
+     "Geisha"
+ ]}
 END;
 
     /**

--- a/tests/Unit/GuzzleFileFetcherTest.php
+++ b/tests/Unit/GuzzleFileFetcherTest.php
@@ -33,22 +33,15 @@ class GuzzleFileFetcherTest extends TestCase
     private $client;
 
     /**
-     * The JSON content of the mocked response(s).
+     * The content of the mocked response(s).
      *
-     * Deliberately includes whitespace in order to prove that the fetcher does
-     * not alter the JSON in any way.
+     * This is deliberately not readable by json_decode(), in order to prove
+     * that the fetcher does not try to parse or process the response content
+     * in any way.
      *
      * @var string
      */
-    private $testContent = <<<END
-{
-  "tea": ["oolong",
-     "assam",   "matcha",
-"herbal"],
-  "coffee" ["Arabica", "Catuai",
-     "Geisha"
- ]}
-END;
+    private $testContent = 'Zombie ipsum reversus ab viral inferno, nam rick grimes malum cerebro.';
 
     /**
      * {@inheritdoc}

--- a/tests/Unit/GuzzleFileFetcherTest.php
+++ b/tests/Unit/GuzzleFileFetcherTest.php
@@ -35,9 +35,17 @@ class GuzzleFileFetcherTest extends TestCase
     /**
      * The JSON content of the mocked response(s).
      *
+     * Deliberately includes whitespace in order to prove that the fetcher does
+     * not alter the JSON in any way.
+     *
      * @var string
      */
-    private $testContent = '["oolong","assam","matcha","herbal"]';
+    private $testContent = <<<END
+["oolong",
+  "assam",
+"matcha",
+"herbal"]
+END;
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
By calling `JsonNormalizer::asNormalizedJson()` on the data that it fetches, GuzzleFileFetcher inadvertently removes whitespace from the fetched data -- which technically changes the contents of the string, and thus its SHA256 hash. Oops.

After discussion with @tedbow, there doesn't seem to be any obvious reason why the fetcher would need to normalize the JSON; its job is to fetch some number of bytes from the Internet and return them in an unaltered state. So let's fix this.