### PR TITLE
JsonNormalizer::asNormalizedJson() should not escape slashes

### DIFF
--- a/src/JsonNormalizer.php
+++ b/src/JsonNormalizer.php
@@ -27,7 +27,7 @@ class JsonNormalizer
     public static function asNormalizedJson(iterable $structure) : string
     {
         self::rKeySort($structure);
-        return json_encode($structure);
+        return json_encode($structure, JSON_UNESCAPED_SLASHES);
     }
 
     /**

--- a/tests/Unit/JsonNormalizerTest.php
+++ b/tests/Unit/JsonNormalizerTest.php
@@ -29,6 +29,8 @@ class JsonNormalizerTest extends TestCase
 
     /**
      * @covers ::asNormalizedJson
+     *
+     * @return void
      */
     public function testSlashEscaping(): void
     {

--- a/tests/Unit/JsonNormalizerTest.php
+++ b/tests/Unit/JsonNormalizerTest.php
@@ -26,4 +26,13 @@ class JsonNormalizerTest extends TestCase
         $this->assertSame(JsonNormalizer::asNormalizedJson($sortedData), $normalizedFromUnsorted);
         $this->assertSame(json_encode($sortedData), $normalizedFromUnsorted);
     }
+
+    /**
+     * @covers ::asNormalizedJson
+     */
+    public function testSlashEscaping(): void
+    {
+        $json = JsonNormalizer::asNormalizedJson(['here/there' => 'everywhere']);
+        $this->assertSame('{"here/there":"everywhere"}', $json);
+    }
 }


### PR DESCRIPTION
JsonNormalizer::asNormalizedJson() currently escapes slashes, which is the default behavior, but this accidentally changes the returned JSON in an undesirable way. Although this could affect anything that goes through asNormalizedJson(), this problem especially affects targets metadata, which contains paths that contain slashes, and ultimately causes signature verification to fail.