### PR TITLE
Support asynchronous HTTP requests

### DIFF
--- a/src/Client/GuzzleFileFetcher.php
+++ b/src/Client/GuzzleFileFetcher.php
@@ -100,7 +100,7 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
      * @return \Closure
      *   The callback function.
      */
-    private function onRejected(string $fileName): \ Closure
+    private function onRejected(string $fileName): \Closure
     {
         return function (\Throwable $e) use ($fileName) {
             if ($e instanceof ClientException) {

--- a/src/Client/GuzzleFileFetcher.php
+++ b/src/Client/GuzzleFileFetcher.php
@@ -76,7 +76,8 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
      * @return \Closure
      *   The callback function.
      */
-    private function onFulfilled(string $fileName, int $maxBytes) : \Closure {
+    private function onFulfilled(string $fileName, int $maxBytes): \Closure
+    {
         return function (ResponseInterface $response) use ($fileName, $maxBytes) {
             $body = $response->getBody();
             $contents = $body->read($maxBytes);
@@ -99,7 +100,8 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
      * @return \Closure
      *   The callback function.
      */
-    private function onRejected(string $fileName): \ Closure {
+    private function onRejected(string $fileName): \ Closure
+    {
         return function (\Throwable $e) use ($fileName) {
             if ($e instanceof ClientException) {
                 if ($e->getCode() === 404) {

--- a/src/Client/RepoFileFetcherInterface.php
+++ b/src/Client/RepoFileFetcherInterface.php
@@ -2,6 +2,7 @@
 
 namespace Tuf\Client;
 
+use GuzzleHttp\Promise\PromiseInterface;
 use Tuf\Exception\RepoFileNotFound;
 
 /**
@@ -28,7 +29,7 @@ interface RepoFileFetcherInterface
      * @throws \Tuf\Exception\DownloadSizeException
      *   Thrown if the file exceeds $maxBytes in size.
      */
-    public function fetchFile(string $fileName, int $maxBytes):string;
+    public function fetchFile(string $fileName, int $maxBytes): PromiseInterface;
 
     /**
      * Gets a file if it exists in the remote repo.

--- a/src/Client/RepoFileFetcherInterface.php
+++ b/src/Client/RepoFileFetcherInterface.php
@@ -19,8 +19,8 @@ interface RepoFileFetcherInterface
      * @param integer $maxBytes
      *   The maximum number of bytes to download.
      *
-     * @return string
-     *   The file contents.
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     *   A promise representing the eventual result of the operation.
      *
      * @throws \Tuf\Exception\RepoFileNotFound
      *   Thrown if the file is not found.

--- a/src/Client/RepoFileFetcherInterface.php
+++ b/src/Client/RepoFileFetcherInterface.php
@@ -3,7 +3,6 @@
 namespace Tuf\Client;
 
 use GuzzleHttp\Promise\PromiseInterface;
-use Tuf\Exception\RepoFileNotFound;
 
 /**
  * Defines an interface for fetching repo files.

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -138,7 +138,7 @@ class Updater
         //$consistent = $rootData['consistent'];
 
         // *TUF-SPEC-v1.0.9 Section 5.2
-        $newTimestampContents = $this->repoFileFetcher->fetchFile('timestamp.json', static::MAXIMUM_DOWNLOAD_BYTES);
+        $newTimestampContents = $this->repoFileFetcher->fetchFile('timestamp.json', static::MAXIMUM_DOWNLOAD_BYTES)->wait();
         $newTimestampData = TimestampMetadata::createFromJson($newTimestampContents);
         // *TUF-SPEC-v1.0.9 Section 5.2.1
         $this->checkSignatures($newTimestampData);
@@ -165,7 +165,7 @@ class Updater
             $newSnapshotContents = $this->repoFileFetcher->fetchFile(
                 "$snapShotVersion.snapshot.json",
                 static::MAXIMUM_DOWNLOAD_BYTES
-            );
+            )->wait();
             // TUF-SPEC-v1.0.9 Section 5.3.1
             $newSnapshotData = SnapshotMetadata::createFromJson($newSnapshotContents);
             $newTimestampData->verifyNewMetaData($newSnapshotData);
@@ -195,7 +195,7 @@ class Updater
             $newTargetsContent = $this->repoFileFetcher->fetchFile(
                 "$targetsVersion.targets.json",
                 static::MAXIMUM_DOWNLOAD_BYTES
-            );
+            )->wait();
             $newTargetsData = TargetsMetadata::createFromJson($newTargetsContent);
             // TUF-SPEC-v1.0.9 Section 5.4.1
             $newSnapshotData->verifyNewMetaData($newTargetsData);

--- a/tests/Client/TestRepo.php
+++ b/tests/Client/TestRepo.php
@@ -4,6 +4,7 @@ namespace Tuf\Tests\Client;
 
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Promise\RejectedPromise;
 use Tuf\Client\RepoFileFetcherInterface;
 use Tuf\Exception\RepoFileNotFound;
 use Tuf\JsonNormalizer;
@@ -45,7 +46,7 @@ class TestRepo implements RepoFileFetcherInterface
     public function fetchFile(string $fileName, int $maxBytes): PromiseInterface
     {
         if (empty($this->repoFilesContents[$fileName])) {
-            throw new RepoFileNotFound("File $fileName not found.");
+            return new RejectedPromise(new RepoFileNotFound("File $fileName not found."));
         }
         return new FulfilledPromise($this->repoFilesContents[$fileName]);
     }

--- a/tests/Client/TestRepo.php
+++ b/tests/Client/TestRepo.php
@@ -2,6 +2,8 @@
 
 namespace Tuf\Tests\Client;
 
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Promise\PromiseInterface;
 use Tuf\Client\RepoFileFetcherInterface;
 use Tuf\Exception\RepoFileNotFound;
 use Tuf\JsonNormalizer;
@@ -40,12 +42,12 @@ class TestRepo implements RepoFileFetcherInterface
     /**
      * {@inheritdoc}
      */
-    public function fetchFile(string $fileName, int $maxBytes):string
+    public function fetchFile(string $fileName, int $maxBytes): PromiseInterface
     {
         if (empty($this->repoFilesContents[$fileName])) {
             throw new RepoFileNotFound("File $fileName not found.");
         }
-        return $this->repoFilesContents[$fileName];
+        return new FulfilledPromise($this->repoFilesContents[$fileName]);
     }
 
     /**
@@ -54,7 +56,7 @@ class TestRepo implements RepoFileFetcherInterface
     public function fetchFileIfExists(string $fileName, int $maxBytes):?string
     {
         try {
-            return $this->fetchFile($fileName, $maxBytes);
+            return $this->fetchFile($fileName, $maxBytes)->wait();
         } catch (RepoFileNotFound $exception) {
             return null;
         }

--- a/tests/Unit/FileStorageTest.php
+++ b/tests/Unit/FileStorageTest.php
@@ -46,6 +46,6 @@ class FileStorageTest extends TestCase
         $this->assertTrue(isset($storage[$filename]));
         $this->assertSame("From hell's heart, I refactor thee!", $storage[$filename]);
         unset($storage[$filename]);
-        $this->assertFileDoesNotExist("$dir/$filename");
+        $this->assertFileNotExists("$dir/$filename");
     }
 }

--- a/tests/Unit/FileStorageTest.php
+++ b/tests/Unit/FileStorageTest.php
@@ -46,6 +46,6 @@ class FileStorageTest extends TestCase
         $this->assertTrue(isset($storage[$filename]));
         $this->assertSame("From hell's heart, I refactor thee!", $storage[$filename]);
         unset($storage[$filename]);
-        $this->assertFileNotExists("$dir/$filename");
+        $this->assertFileDoesNotExist("$dir/$filename");
     }
 }

--- a/tests/Unit/GuzzleFileFetcherTest.php
+++ b/tests/Unit/GuzzleFileFetcherTest.php
@@ -154,7 +154,7 @@ class GuzzleFileFetcherTest extends TestCase
     {
         $fetcher = new GuzzleFileFetcher($this->client);
         $this->mockHandler->append(new Response(200, [], $this->testContent));
-        $this->assertSame($fetcher->fetchFile('test.json', 256), $this->testContent);
+        $this->assertSame($fetcher->fetchFile('test.json', 256)->wait(), $this->testContent);
         $this->mockHandler->append(new Response(200, [], $this->testContent));
         $this->assertSame($fetcher->fetchFileIfExists('test.json', 256), $this->testContent);
         $this->mockHandler->append(new Response(404, []));

--- a/tests/Unit/GuzzleFileFetcherTest.php
+++ b/tests/Unit/GuzzleFileFetcherTest.php
@@ -114,7 +114,7 @@ class GuzzleFileFetcherTest extends TestCase
         $this->expectException($exceptionClass);
         $this->expectExceptionCode($exceptionCode ?? $statusCode);
         $fetcher = new GuzzleFileFetcher($this->client);
-        $fetcher->fetchFile('test.json', $maxBytes ?? strlen($this->testContent));
+        $fetcher->fetchFile('test.json', $maxBytes ?? strlen($this->testContent))->wait();
     }
 
     /**


### PR DESCRIPTION
As we integrate Composer with TUF, it's become obvious that TUF will need to support the ability to fetch metadata and files asynchronously, since this is something Composer does already and is a major part of Composer 2's massive speed improvements. Right now, all our HTTP operations are synchronous, which makes sense for Updater::refresh(), but once the metadata is refreshed, we need to be able to fetch things like Composer's package metadata, and actual package artifacts, asynchronously.

The good news is, Guzzle already has great support for async operations using its own promises library. So we should take advantage of that and require RepoFileFetcher::fetchFile() to always return a promise. This should open the door to TUF downloading things and verifying them asynchronously.