### PR TITLE
Add a method to get known hashes of a target

### DIFF
--- a/src/Metadata/TargetsMetadata.php
+++ b/src/Metadata/TargetsMetadata.php
@@ -65,4 +65,40 @@ class TargetsMetadata extends MetadataBase
         ]);
         return $options;
     }
+
+    /**
+     * Returns the known hashes for a specific target.
+     *
+     * @param string $target
+     *   The target path.
+     *
+     * @return \ArrayObject
+     *   The known hashes for the object. The keys are the hash algorithm (e.g.
+s     *   'sha256') and the values are the hash digest.
+     */
+    public function getHashes(string $target): \ArrayObject
+    {
+        return $this->getInfo($target)['hashes'];
+    }
+
+    /**
+     * Gets info about a specific target.
+     *
+     * @param string $target
+     *   The target path.
+     *
+     * @return \ArrayObject
+     *   The target's info.
+     *
+     * @throws \InvalidArgumentException
+     *   Thrown if the target is not mentioned in this metadata.
+     */
+    protected function getInfo(string $target): \ArrayObject
+    {
+        $signed = $this->getSigned();
+        if (isset($signed['targets'][$target])) {
+            return $signed['targets'][$target];
+        }
+        throw new \InvalidArgumentException("Unknown target: '$target'");
+    }
 }

--- a/src/Metadata/TargetsMetadata.php
+++ b/src/Metadata/TargetsMetadata.php
@@ -74,7 +74,7 @@ class TargetsMetadata extends MetadataBase
      *
      * @return \ArrayObject
      *   The known hashes for the object. The keys are the hash algorithm (e.g.
-s     *   'sha256') and the values are the hash digest.
+     *   'sha256') and the values are the hash digest.
      */
     public function getHashes(string $target): \ArrayObject
     {

--- a/tests/Metadata/TargetsMetadataTest.php
+++ b/tests/Metadata/TargetsMetadataTest.php
@@ -27,6 +27,21 @@ class TargetsMetadataTest extends MetaDataBaseTest
         return TargetsMetadata::createFromJson($json);
     }
 
+    /**
+     * @covers ::getHashes
+     *
+     * @return void
+     *   Describe the void.
+     */
+    public function testGetHashes(): void
+    {
+        $json = $this->localRepo[$this->validJson];
+        $metadata = TargetsMetadata::createFromJson($json);
+        $json = json_decode($json, true);
+
+        $target = key($json['signed']['targets']);
+        $this->assertSame($metadata->getHashes($target)->getArrayCopy(), $json['signed']['targets'][$target]['hashes']);
+    }
 
     /**
      * {@inheritdoc}
@@ -48,6 +63,8 @@ class TargetsMetadataTest extends MetaDataBaseTest
         $data[] = ['signed:delegations:roles:0:paths'];
         $data[] = ['signed:delegations:roles:0:terminating'];
         $data[] = ['signed:delegations:roles:0:threshold'];
+        $target = $this->getFixtureNestedArrayFirstKey($this->validJson, ['signed', 'targets']);
+        $data[] = ["signed:targets:$target:hashes"];
         return static::getKeyedArray($data);
     }
 

--- a/tests/Metadata/TargetsMetadataTest.php
+++ b/tests/Metadata/TargetsMetadataTest.php
@@ -41,6 +41,10 @@ class TargetsMetadataTest extends MetaDataBaseTest
 
         $target = key($json['signed']['targets']);
         $this->assertSame($metadata->getHashes($target)->getArrayCopy(), $json['signed']['targets'][$target]['hashes']);
+
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage("Unknown target: 'void.txt'");
+        $metadata->getHashes('void.txt');
     }
 
     /**

--- a/tests/Metadata/TargetsMetadataTest.php
+++ b/tests/Metadata/TargetsMetadataTest.php
@@ -78,7 +78,8 @@ class TargetsMetadataTest extends MetaDataBaseTest
     public function providerValidField() : array
     {
         $data = parent::providerValidField();
-        // @todo Add targets specifics.
+        $target = $this->getFixtureNestedArrayFirstKey($this->validJson, ['signed', 'targets']);
+        $data[] = ["signed:targets:$target:hashes", 'array'];
         return $data;
     }
 }


### PR DESCRIPTION
To get #113 done, we'll need a way to get the known hashes for a target. This adds a method for that to TargetsMetadata, plus test coverage.