### PR TITLE
Promises returned by RepoFileFetcherInterface should wrap streams

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "paragonie/sodium_compat": "^1.13",
         "symfony/validator": "^4.4 || ^5",
         "guzzlehttp/guzzle": "^6.5 || ^7.2",
-        "myclabs/deep-copy": "^1.10.2"
+        "myclabs/deep-copy": "^1.10.2",
+        "guzzlehttp/psr7": "^1.7"
     },
     "suggest": {
         "ext-libsodium": "Provides faster verification of updates"

--- a/src/Client/GuzzleFileFetcher.php
+++ b/src/Client/GuzzleFileFetcher.php
@@ -96,12 +96,13 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
     {
         return function (ResponseInterface $response) use ($fileName, $maxBytes) {
             $body = $response->getBody();
-            $contents = $body->read($maxBytes);
+            $body->read($maxBytes);
 
             // If we reached the end of the stream, we didn't exceed the maximum
             // number of bytes.
             if ($body->eof() === true) {
-                return $contents;
+                $body->rewind();
+                return $body;
             }
             throw new DownloadSizeException("$fileName exceeded $maxBytes bytes");
         };

--- a/src/Client/RepoFileFetcherInterface.php
+++ b/src/Client/RepoFileFetcherInterface.php
@@ -18,7 +18,10 @@ interface RepoFileFetcherInterface
      *   The maximum number of bytes to download.
      *
      * @return \GuzzleHttp\Promise\PromiseInterface
-     *   A promise representing the eventual result of the operation.
+     *   A promise representing the eventual result of the operation. If
+     *   successful, the promise should wrap around an instance of
+     *   \Psr\Http\Message\StreamInterface, which provides a stream of the
+     *   retrieved data.
      */
     public function fetchMetaData(string $fileName, int $maxBytes): PromiseInterface;
 
@@ -31,7 +34,10 @@ interface RepoFileFetcherInterface
      *   The maximum number of bytes to download.
      *
      * @return \GuzzleHttp\Promise\PromiseInterface
-     *   A promise representing the eventual result of the operation.
+     *   A promise representing the eventual result of the operation. If
+     *   successful, the promise should wrap around an instance of
+     *   \Psr\Http\Message\StreamInterface, which provides a stream of the
+     *   retrieved data.
      */
     public function fetchTarget(string $fileName, int $maxBytes): PromiseInterface;
 

--- a/tests/Client/TestRepo.php
+++ b/tests/Client/TestRepo.php
@@ -5,6 +5,7 @@ namespace Tuf\Tests\Client;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\RejectedPromise;
+use GuzzleHttp\Psr7\Utils;
 use Tuf\Client\RepoFileFetcherInterface;
 use Tuf\Exception\RepoFileNotFound;
 use Tuf\JsonNormalizer;
@@ -64,7 +65,8 @@ class TestRepo implements RepoFileFetcherInterface
         if (empty($this->repoFilesContents[$fileName])) {
             return new RejectedPromise(new RepoFileNotFound("File $fileName not found."));
         }
-        return new FulfilledPromise($this->repoFilesContents[$fileName]);
+        $stream = Utils::streamFor($this->repoFilesContents[$fileName]);
+        return new FulfilledPromise($stream);
     }
 
     /**

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -116,7 +116,7 @@ class UpdaterTest extends TestCase
 
         $testFileContents = file_get_contents(__DIR__ . '/../../fixtures/TUFTestFixtureSimple/tufrepo/targets/testtarget.txt');
         $this->testRepo->repoFilesContents['testtarget.txt'] = $testFileContents;
-        $this->assertSame($testFileContents, $updater->download('testtarget.txt')->wait());
+        $this->assertSame($testFileContents, $updater->download('testtarget.txt')->wait()->getContents());
 
         $this->testRepo->repoFilesContents['testtarget.txt'] = 'invalid data';
         $this->expectException(InvalidHashException::class);

--- a/tests/Unit/GuzzleFileFetcherTest.php
+++ b/tests/Unit/GuzzleFileFetcherTest.php
@@ -154,7 +154,7 @@ class GuzzleFileFetcherTest extends TestCase
     {
         $fetcher = new GuzzleFileFetcher($this->client);
         $this->mockHandler->append(new Response(200, [], $this->testContent));
-        $this->assertSame($fetcher->fetchMetaData('test.json', 256)->wait(), $this->testContent);
+        $this->assertSame($fetcher->fetchMetaData('test.json', 256)->wait()->getContents(), $this->testContent);
         $this->mockHandler->append(new Response(200, [], $this->testContent));
         $this->assertSame($fetcher->fetchMetaDataIfExists('test.json', 256), $this->testContent);
         $this->mockHandler->append(new Response(404, []));


### PR DESCRIPTION
As I've been discovering, we need to be able to handle two kinds of data retrieval from the Internet: strings, and files. I've been trying to figure out how to do this consistently -- in other words, we already use promises for all our HTTP transactions, but what should the promises wrap around if some of the transactions should return strings, and others should just download files without returning their contents?

Having pondered it for a couple of days, I believe the answer is streams, which Guzzle already supports using its own PSR-7 implementation. RepoFileFetcherInterface's promises should always wrap around an instance of StreamInterface, which could be referring either to a string in memory, or a file downloaded on disk (whose path we can retrieve as part of the stream metadata). This adds a further layer of normalization and consistency to our API, and leverages another library (in addition to Guzzle's promises library) that we have as an indirect dependency.