### PR TITLE
Use hash_file() to verify file streams where appropriate

### DIFF
--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -546,24 +546,22 @@ class Updater
         $length = $targetsMetaData->getLength($target) ?? static::MAXIMUM_DOWNLOAD_BYTES;
 
         $verify = function (StreamInterface $stream) use ($target, $hashes) {
-            // If the stream has a URI that refers to a file, use hash_file() to
-            // verify it. Otherwise, read the entire stream as a string and use
-            // hash() to verify it.
-            $uri = $stream->getMetadata('uri');
-            if ($uri && file_exists($uri)) {
-                $content = $uri;
-                $verifier = 'hash_file';
-            } else {
-                $content = $stream->getContents();
-                $verifier = 'hash';
-            }
-
             foreach ($hashes as $algo => $hash) {
-                if ($hash !== $verifier($algo, $content)) {
+                // If the stream has a URI that refers to a file, use
+                // hash_file() to verify it. Otherwise, read the entire stream
+                // as a string and use hash() to verify it.
+                $uri = $stream->getMetadata('uri');
+                if ($uri && file_exists($uri)) {
+                    $streamHash = hash_file($algo, $uri);
+                } else {
+                    $streamHash = hash($algo, $stream->getContents());
+                    $stream->rewind();
+                }
+
+                if ($hash !== $streamHash) {
                     throw new InvalidHashException("Invalid $algo hash for $target");
                 }
             }
-            $stream->rewind();
             return $stream;
         };
 

--- a/tests/Client/TestRepo.php
+++ b/tests/Client/TestRepo.php
@@ -65,6 +65,12 @@ class TestRepo implements RepoFileFetcherInterface
         if (empty($this->repoFilesContents[$fileName])) {
             return new RejectedPromise(new RepoFileNotFound("File $fileName not found."));
         }
+        // Allow test code to directly set the returned promise so that the
+        // underlying streams can be mocked.
+        $contents = $this->repoFilesContents[$fileName];
+        if ($contents instanceof PromiseInterface) {
+            return $contents;
+        }
         $stream = Utils::streamFor($this->repoFilesContents[$fileName]);
         return new FulfilledPromise($stream);
     }

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -115,7 +115,7 @@ class UpdaterTest extends TestCase
         $this->testRepo = new TestRepo($fixturesSet);
         $updater = $this->getSystemInTest();
 
-        $testFilePath = static::getFixturesRealPath('TUFTestFixtureSimple', 'tufrepo/targets/testtarget.txt', false);
+        $testFilePath = static::getFixturesRealPath($fixturesSet, 'tufrepo/targets/testtarget.txt', false);
         $testFileContents = file_get_contents($testFilePath);
         $this->testRepo->repoFilesContents['testtarget.txt'] = $testFileContents;
         $this->assertSame($testFileContents, $updater->download('testtarget.txt')->wait()->getContents());

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -2,6 +2,7 @@
 
 namespace Tuf\Tests\Client;
 
+use GuzzleHttp\Promise\FulfilledPromise;
 use PHPUnit\Framework\TestCase;
 use Tuf\Client\Updater;
 use Tuf\Exception\MetadataException;
@@ -114,9 +115,19 @@ class UpdaterTest extends TestCase
         $this->testRepo = new TestRepo($fixturesSet);
         $updater = $this->getSystemInTest();
 
-        $testFileContents = file_get_contents(__DIR__ . '/../../fixtures/TUFTestFixtureSimple/tufrepo/targets/testtarget.txt');
+        $testFilePath = realpath(__DIR__ . '/../../fixtures/TUFTestFixtureSimple/tufrepo/targets/testtarget.txt');
+        $testFileContents = file_get_contents($testFilePath);
         $this->testRepo->repoFilesContents['testtarget.txt'] = $testFileContents;
         $this->assertSame($testFileContents, $updater->download('testtarget.txt')->wait()->getContents());
+
+        // If the file fetcher returns a file stream, the updater should NOT try
+        // to read the contents of the stream into memory.
+        $stream = $this->prophesize('\Psr\Http\Message\StreamInterface');
+        $stream->getMetadata('uri')->willReturn($testFilePath);
+        $stream->getContents()->shouldNotBeCalled();
+        $stream->rewind()->shouldBeCalled();
+        $this->testRepo->repoFilesContents['testtarget.txt'] = new FulfilledPromise($stream->reveal());
+        $updater->download('testtarget.txt')->wait();
 
         $this->testRepo->repoFilesContents['testtarget.txt'] = 'invalid data';
         $this->expectException(InvalidHashException::class);

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -115,7 +115,7 @@ class UpdaterTest extends TestCase
         $this->testRepo = new TestRepo($fixturesSet);
         $updater = $this->getSystemInTest();
 
-        $testFilePath = realpath(__DIR__ . '/../../fixtures/TUFTestFixtureSimple/tufrepo/targets/testtarget.txt');
+        $testFilePath = static::getFixturesRealPath('TUFTestFixtureSimple', 'tufrepo/targets/testtarget.txt', false);
         $testFileContents = file_get_contents($testFilePath);
         $this->testRepo->repoFilesContents['testtarget.txt'] = $testFileContents;
         $this->assertSame($testFileContents, $updater->download('testtarget.txt')->wait()->getContents());
@@ -125,7 +125,7 @@ class UpdaterTest extends TestCase
         $stream = $this->prophesize('\Psr\Http\Message\StreamInterface');
         $stream->getMetadata('uri')->willReturn($testFilePath);
         $stream->getContents()->shouldNotBeCalled();
-        $stream->rewind()->shouldBeCalled();
+        $stream->rewind()->shouldNotBeCalled();
         $this->testRepo->repoFilesContents['testtarget.txt'] = new FulfilledPromise($stream->reveal());
         $updater->download('testtarget.txt')->wait();
 


### PR DESCRIPTION
Now that we have adopted streams (in #119), we need to support the ability to call `hash_file()` for verification of downloaded data, so that we don't _always_ need to read the entire contents of the stream into memory to compute the hash.

According to https://www.php.net/stream_get_meta_data, streams can have a `uri` metadata property which refers to their source -- which could be a file path, if that's where Guzzle saved the downloaded data. We should leverage that property to see if the stream is coming from a (downloaded) file, and use hash_file() in that case.