### PR TITLE
Add a StreamInterface implementation that is aware of the HTTP response

### DIFF
--- a/src/Client/GuzzleFileFetcher.php
+++ b/src/Client/GuzzleFileFetcher.php
@@ -124,7 +124,7 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
                 }
                 $body->rewind();
             }
-            return new ResponseAwareStream($body, $response);
+            return new ResponseStream($response);
         };
     }
 

--- a/src/Client/GuzzleFileFetcher.php
+++ b/src/Client/GuzzleFileFetcher.php
@@ -124,7 +124,7 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
                 }
                 $body->rewind();
             }
-            return $body;
+            return new ResponseAwareStream($body, $response);
         };
     }
 

--- a/src/Client/ResponseAwareStream.php
+++ b/src/Client/ResponseAwareStream.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Tuf\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * Defines an adapter class for a stream that is aware of an HTTP response.
+ *
+ * This exists because \Tuf\Client\RepoFileFetcherInterface's methods return
+ * promises that wrap around instances of StreamInterface, but some consumers
+ * of this library might need information about the HTTP response too, if a
+ * request was made.
+ */
+class ResponseAwareStream implements StreamInterface
+{
+    /**
+     * A stream (i.e., the body of an HTTP response).
+     *
+     * @var \Psr\Http\Message\StreamInterface
+     */
+    private $stream;
+
+    /**
+     * The response that produced the stream.
+     *
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+
+    /**
+     * ResponseAwareStream constructor.
+     *
+     * @param \Psr\Http\Message\StreamInterface $stream
+     *   A stream (i.e., the body of an HTTP response).
+     * @param \Psr\Http\Message\ResponseInterface $response
+     *   The response that produced the stream.
+     */
+    public function __construct(StreamInterface $stream, ResponseInterface $response)
+    {
+        $this->stream = $stream;
+        $this->response = $response;
+    }
+
+    /**
+     * Returns the response that produced this stream.
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     *    The response.
+     */
+    public function getResponse(): ResponseInterface
+    {
+        return $this->response;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __toString()
+    {
+        return $this->stream->__toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function close()
+    {
+        $this->stream->close();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function detach()
+    {
+        return $this->stream->detach();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getSize()
+    {
+        return $this->stream->getSize();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tell()
+    {
+        return $this->stream->tell();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function eof()
+    {
+        return $this->stream->eof();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isSeekable()
+    {
+        return $this->stream->isSeekable();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function seek($offset, $whence = SEEK_SET)
+    {
+        return $this->stream->seek($offset, $whence);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function rewind()
+    {
+        return $this->stream->rewind();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isWritable()
+    {
+        return $this->stream->isWritable();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function write($string)
+    {
+        return $this->stream->write($string);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isReadable()
+    {
+        return $this->stream->isReadable();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function read($length)
+    {
+        return $this->stream->read($length);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getContents()
+    {
+        return $this->stream->getContents();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getMetadata($key = null)
+    {
+        return $this->stream->getMetadata($key);
+    }
+}

--- a/src/Client/ResponseStream.php
+++ b/src/Client/ResponseStream.php
@@ -6,22 +6,15 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 
 /**
- * Defines an adapter class for a stream that is aware of an HTTP response.
+ * Defines an adapter for a stream that comes from an HTTP response.
  *
  * This exists because \Tuf\Client\RepoFileFetcherInterface's methods return
  * promises that wrap around instances of StreamInterface, but some consumers
  * of this library might need information about the HTTP response too, if a
  * request was made.
  */
-class ResponseAwareStream implements StreamInterface
+class ResponseStream implements StreamInterface
 {
-    /**
-     * A stream (i.e., the body of an HTTP response).
-     *
-     * @var \Psr\Http\Message\StreamInterface
-     */
-    private $stream;
-
     /**
      * The response that produced the stream.
      *
@@ -32,14 +25,11 @@ class ResponseAwareStream implements StreamInterface
     /**
      * ResponseAwareStream constructor.
      *
-     * @param \Psr\Http\Message\StreamInterface $stream
-     *   A stream (i.e., the body of an HTTP response).
      * @param \Psr\Http\Message\ResponseInterface $response
      *   The response that produced the stream.
      */
-    public function __construct(StreamInterface $stream, ResponseInterface $response)
+    public function __construct(ResponseInterface $response)
     {
-        $this->stream = $stream;
         $this->response = $response;
     }
 
@@ -59,7 +49,7 @@ class ResponseAwareStream implements StreamInterface
      */
     public function __toString()
     {
-        return $this->stream->__toString();
+        return $this->getResponse()->getBody()->__toString();
     }
 
     /**
@@ -67,7 +57,7 @@ class ResponseAwareStream implements StreamInterface
      */
     public function close()
     {
-        $this->stream->close();
+        $this->getResponse()->getBody()->close();
     }
 
     /**
@@ -75,7 +65,7 @@ class ResponseAwareStream implements StreamInterface
      */
     public function detach()
     {
-        return $this->stream->detach();
+        return $this->getResponse()->getBody()->detach();
     }
 
     /**
@@ -83,7 +73,7 @@ class ResponseAwareStream implements StreamInterface
      */
     public function getSize()
     {
-        return $this->stream->getSize();
+        return $this->getResponse()->getBody()->getSize();
     }
 
     /**
@@ -91,7 +81,7 @@ class ResponseAwareStream implements StreamInterface
      */
     public function tell()
     {
-        return $this->stream->tell();
+        return $this->getResponse()->getBody()->tell();
     }
 
     /**
@@ -99,7 +89,7 @@ class ResponseAwareStream implements StreamInterface
      */
     public function eof()
     {
-        return $this->stream->eof();
+        return $this->getResponse()->getBody()->eof();
     }
 
     /**
@@ -107,7 +97,7 @@ class ResponseAwareStream implements StreamInterface
      */
     public function isSeekable()
     {
-        return $this->stream->isSeekable();
+        return $this->getResponse()->getBody()->isSeekable();
     }
 
     /**
@@ -115,7 +105,7 @@ class ResponseAwareStream implements StreamInterface
      */
     public function seek($offset, $whence = SEEK_SET)
     {
-        return $this->stream->seek($offset, $whence);
+        return $this->getResponse()->getBody()->seek($offset, $whence);
     }
 
     /**
@@ -123,7 +113,7 @@ class ResponseAwareStream implements StreamInterface
      */
     public function rewind()
     {
-        return $this->stream->rewind();
+        return $this->getResponse()->getBody()->rewind();
     }
 
     /**
@@ -131,7 +121,7 @@ class ResponseAwareStream implements StreamInterface
      */
     public function isWritable()
     {
-        return $this->stream->isWritable();
+        return $this->getResponse()->getBody()->isWritable();
     }
 
     /**
@@ -139,7 +129,7 @@ class ResponseAwareStream implements StreamInterface
      */
     public function write($string)
     {
-        return $this->stream->write($string);
+        return $this->getResponse()->getBody()->write($string);
     }
 
     /**
@@ -147,7 +137,7 @@ class ResponseAwareStream implements StreamInterface
      */
     public function isReadable()
     {
-        return $this->stream->isReadable();
+        return $this->getResponse()->getBody()->isReadable();
     }
 
     /**
@@ -155,7 +145,7 @@ class ResponseAwareStream implements StreamInterface
      */
     public function read($length)
     {
-        return $this->stream->read($length);
+        return $this->getResponse()->getBody()->read($length);
     }
 
     /**
@@ -163,7 +153,7 @@ class ResponseAwareStream implements StreamInterface
      */
     public function getContents()
     {
-        return $this->stream->getContents();
+        return $this->getResponse()->getBody()->getContents();
     }
 
     /**
@@ -171,6 +161,6 @@ class ResponseAwareStream implements StreamInterface
      */
     public function getMetadata($key = null)
     {
-        return $this->stream->getMetadata($key);
+        return $this->getResponse()->getBody()->getMetadata($key);
     }
 }


### PR DESCRIPTION
In some cases, consumers of TUF (right now, that means php-tuf/composer-integration) will need information about the HTTP response that came back from a request. Right now, though, our promises wrap streams -- which is good. The streams have zero awareness about the response (or even that they were produced by an HTTP transaction) -- which is also good. But for integrating with Composer (and possibly other things), it's too limiting.

I propose to add a simple adapter class which implements `StreamInterface`, and wraps around both a stream _and_ the response which produced the stream. That way, calling code can examine the response if it needs to, but also continue to use the resulting stream as any other.