### PR TITLE
GuzzleFileFetcher::create() should allow HTTP URIs

### DIFF
--- a/src/Client/GuzzleFileFetcher.php
+++ b/src/Client/GuzzleFileFetcher.php
@@ -45,13 +45,8 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
      */
     public static function createFromUri(string $baseUri) : self
     {
-        $scheme = parse_url($baseUri, PHP_URL_SCHEME);
-        if ($scheme === 'https') {
-            $client = new Client(['base_uri' => $baseUri]);
-            return new static($client);
-        } else {
-            throw new \InvalidArgumentException("Repo base URI must be HTTPS: $baseUri");
-        }
+        $client = new Client(['base_uri' => $baseUri]);
+        return new static($client);
     }
 
     /**

--- a/tests/Unit/GuzzleFileFetcherTest.php
+++ b/tests/Unit/GuzzleFileFetcherTest.php
@@ -171,9 +171,5 @@ class GuzzleFileFetcherTest extends TestCase
     public function testCreateFromUri(): void
     {
         $this->assertInstanceOf(GuzzleFileFetcher::class, GuzzleFileFetcher::createFromUri('https://example.com'));
-
-        $this->expectException('InvalidArgumentException');
-        $this->expectExceptionMessage('Repo base URI must be HTTPS: http://example.com');
-        GuzzleFileFetcher::createFromUri('http://example.com');
     }
 }


### PR DESCRIPTION
Right now, GuzzleFileFetcher::create() throws an exception if you give it a non-HTTPS URI. Since HTTPS is not the main form of security in TUF, this is needlessly restrictive.