### PR TITLE
Allow file fetchers to accept idiosyncratic options

### DIFF
--- a/src/Client/GuzzleFileFetcher.php
+++ b/src/Client/GuzzleFileFetcher.php
@@ -65,15 +65,15 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
     /**
      * {@inheritDoc}
      */
-    public function fetchTarget(string $fileName, int $maxBytes): PromiseInterface
+    public function fetchTarget(string $fileName, int $maxBytes, array $options = []): PromiseInterface
     {
-        return $this->fetchFile($fileName, $maxBytes);
+        return $this->fetchFile($fileName, $maxBytes, $options);
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function fetchFile(string $fileName, int $maxBytes): PromiseInterface
+    protected function fetchFile(string $fileName, int $maxBytes, array $options = []): PromiseInterface
     {
         // Create a progress callback to abort the download if it exceeds
         // $maxBytes. This will only work with cURL, so we also verify the
@@ -83,8 +83,7 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
                 throw new DownloadSizeException("$fileName exceeded $maxBytes bytes");
             }
         };
-        $options = [];
-        $options[RequestOptions::PROGRESS] = $progress;
+        $options += [RequestOptions::PROGRESS => $progress];
 
         return $this->client->requestAsync('GET', $fileName, $options)
             ->then(

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -524,12 +524,14 @@ class Updater
      * @param string $target
      *   The path of the target file. Needs to be known to the most recent
      *   targets metadata downloaded in ::refresh().
+     * @param mixed ...$extra
+     *   Additional arguments to pass to the file fetcher.
      *
      * @return \GuzzleHttp\Promise\PromiseInterface
      *   A promise representing the eventual verified result of the download
      *   operation.
      */
-    public function download(string $target): PromiseInterface
+    public function download(string $target,  ...$extra): PromiseInterface
     {
         if (!$this->isRefreshed) {
             $this->refresh();
@@ -565,7 +567,7 @@ class Updater
             return $stream;
         };
 
-        return $this->repoFileFetcher->fetchTarget($target, $length)
+        return $this->repoFileFetcher->fetchTarget($target, $length, ...$extra)
             ->then($verify);
     }
 }

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -531,7 +531,7 @@ class Updater
      *   A promise representing the eventual verified result of the download
      *   operation.
      */
-    public function download(string $target,  ...$extra): PromiseInterface
+    public function download(string $target, ...$extra): PromiseInterface
     {
         if (!$this->isRefreshed) {
             $this->refresh();


### PR DESCRIPTION
As with #121, this is a minor API change to support Composer integration in a consumer-agnostic way. This will allow the plugin to pass the `sink` option to the Guzzle file fetcher, which will make Guzzle download a target to a specific path (Composer's `HttpDownloader` has a similar functionality, so this lets us parallel that).