### PR TITLE
Updater::download() should return a rejected promise if the target is invalid

### DIFF
--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -3,6 +3,7 @@
 namespace Tuf\Tests\Client;
 
 use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Promise\RejectedPromise;
 use PHPUnit\Framework\TestCase;
 use Tuf\Client\Updater;
 use Tuf\Exception\MetadataException;
@@ -128,6 +129,10 @@ class UpdaterTest extends TestCase
         $stream->rewind()->shouldNotBeCalled();
         $this->testRepo->repoFilesContents['testtarget.txt'] = new FulfilledPromise($stream->reveal());
         $updater->download('testtarget.txt')->wait();
+
+        // If the target isn't known, we should get a rejected promise.
+        $promise = $updater->download('void.txt');
+        $this->assertInstanceOf(RejectedPromise::class, $promise);
 
         $this->testRepo->repoFilesContents['testtarget.txt'] = 'invalid data';
         $this->expectException(InvalidHashException::class);


### PR DESCRIPTION
`Updater::download()` is not really doing the right thing if the requested target is either non-existent or has no trusted hashes. It's _supposed_ to return a promise, but instead it's immediately throwing an exception, which means calling code needs to have a try-catch around a promise. That's nuts. Instead, it should just immediately return a rejected promise, which makes more sense given how promises are supposed to work.