### PR TITLE
Support path prefixes for metadata and targets in GuzzleFileFetcher

### DIFF
--- a/src/Client/GuzzleFileFetcher.php
+++ b/src/Client/GuzzleFileFetcher.php
@@ -24,14 +24,34 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
     private $client;
 
     /**
+     * The path prefix for metadata.
+     *
+     * @var string|null
+     */
+    private $metaDataPrefix;
+
+    /**
+     * The path prefix for targets.
+     *
+     * @var string|null
+     */
+    private $targetsPrefix;
+
+    /**
      * GuzzleFileFetcher constructor.
      *
      * @param \GuzzleHttp\ClientInterface $client
      *   The HTTP client.
+     * @param string|null $metaDataPrefix
+     *   (optional) The path prefix for metadata.
+     * @param string|null $targetsPrefix
+     *   (optional) The path prefix for targets.
      */
-    public function __construct(ClientInterface $client)
+    public function __construct(ClientInterface $client, string $metaDataPrefix = null, string $targetsPrefix = null)
     {
         $this->client = $client;
+        $this->metaDataPrefix = $metaDataPrefix;
+        $this->targetsPrefix = $targetsPrefix;
     }
 
     /**
@@ -54,7 +74,7 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
      */
     public function fetchMetaData(string $fileName, int $maxBytes): PromiseInterface
     {
-        return $this->fetchFile($fileName, $maxBytes);
+        return $this->fetchFile($this->metaDataPrefix . $fileName, $maxBytes);
     }
 
     /**
@@ -62,7 +82,7 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
      */
     public function fetchTarget(string $fileName, int $maxBytes, array $options = []): PromiseInterface
     {
-        return $this->fetchFile($fileName, $maxBytes, $options);
+        return $this->fetchFile($this->targetsPrefix . $fileName, $maxBytes, $options);
     }
 
     /**

--- a/src/Client/GuzzleFileFetcher.php
+++ b/src/Client/GuzzleFileFetcher.php
@@ -42,12 +42,12 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
      *
      * @param \GuzzleHttp\ClientInterface $client
      *   The HTTP client.
-     * @param string|null $metaDataPrefix
-     *   (optional) The path prefix for metadata.
-     * @param string|null $targetsPrefix
-     *   (optional) The path prefix for targets.
+     * @param string $metaDataPrefix
+     *   The path prefix for metadata.
+     * @param string $targetsPrefix
+     *   The path prefix for targets.
      */
-    public function __construct(ClientInterface $client, string $metaDataPrefix = null, string $targetsPrefix = null)
+    public function __construct(ClientInterface $client, string $metaDataPrefix, string $targetsPrefix)
     {
         $this->client = $client;
         $this->metaDataPrefix = $metaDataPrefix;
@@ -59,14 +59,18 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
      *
      * @param string $baseUri
      *   The base URI from which to fetch files.
+     * @param string $metaDataPrefix
+     *   (optional) The path prefix for metadata. Defaults to '/metadata/'.
+     * @param string $targetsPrefix
+     *   (optional) The path prefix for targets. Defaults to '/targets/'.
      *
      * @return static
      *   A new instance of this class.
      */
-    public static function createFromUri(string $baseUri) : self
+    public static function createFromUri(string $baseUri, string $metaDataPrefix = '/metadata/', string $targetsPrefix = '/targets/') : self
     {
         $client = new Client(['base_uri' => $baseUri]);
-        return new static($client);
+        return new static($client, $metaDataPrefix, $targetsPrefix);
     }
 
     /**

--- a/tests/Unit/GuzzleFileFetcherTest.php
+++ b/tests/Unit/GuzzleFileFetcherTest.php
@@ -182,7 +182,7 @@ class GuzzleFileFetcherTest extends TestCase
      */
     public function testPrefixes(): void
     {
-        $promise = new FulfilledPromise('Helloooo!');
+        $promise = new FulfilledPromise(new Response());
 
         $client = $this->prophesize('\GuzzleHttp\ClientInterface');
         $client->requestAsync('GET', '/metadata/root.json', Argument::type('array'))

--- a/tests/Unit/GuzzleFileFetcherTest.php
+++ b/tests/Unit/GuzzleFileFetcherTest.php
@@ -61,6 +61,17 @@ class GuzzleFileFetcherTest extends TestCase
     }
 
     /**
+     * Returns an instance of the file fetcher under test.
+     *
+     * @return \Tuf\Client\GuzzleFileFetcher
+     *   An instance of the file fetcher under test.
+     */
+    private function getFetcher(): GuzzleFileFetcher
+    {
+        return new GuzzleFileFetcher($this->client, '/metadata/', '/targets/');
+    }
+
+    /**
      * Data provider for testfetchFileError().
      *
      * @return array[]
@@ -115,8 +126,9 @@ class GuzzleFileFetcherTest extends TestCase
         $this->mockHandler->append(new Response($statusCode, [], $this->testContent));
         $this->expectException($exceptionClass);
         $this->expectExceptionCode($exceptionCode ?? $statusCode);
-        $fetcher = new GuzzleFileFetcher($this->client);
-        $fetcher->fetchMetaData('test.json', $maxBytes ?? strlen($this->testContent))->wait();
+        $this->getFetcher()
+            ->fetchMetaData('test.json', $maxBytes ?? strlen($this->testContent))
+            ->wait();
     }
 
     /**
@@ -143,8 +155,8 @@ class GuzzleFileFetcherTest extends TestCase
         $this->mockHandler->append(new Response($statusCode, [], $this->testContent));
         $this->expectException($exceptionClass);
         $this->expectExceptionCode($exceptionCode ?? $statusCode);
-        $fetcher = new GuzzleFileFetcher($this->client);
-        $fetcher->fetchMetaDataIfExists('test.json', $maxBytes ?? strlen($this->testContent));
+        $this->getFetcher()
+            ->fetchMetaDataIfExists('test.json', $maxBytes ?? strlen($this->testContent));
     }
 
     /**
@@ -154,7 +166,7 @@ class GuzzleFileFetcherTest extends TestCase
      */
     public function testSuccessfulFetch(): void
     {
-        $fetcher = new GuzzleFileFetcher($this->client);
+        $fetcher = $this->getFetcher();
         $this->mockHandler->append(new Response(200, [], $this->testContent));
         $this->assertSame($fetcher->fetchMetaData('test.json', 256)->wait()->getContents(), $this->testContent);
         $this->mockHandler->append(new Response(200, [], $this->testContent));


### PR DESCRIPTION
The Python repository tool generates the repository in a specific way: TUF metadata goes into a `/metadata` directory, and the actual targets go into `/targets`. GuzzleFileFetcher should make it easier to deal with this layout by optionally remembering the path prefixes for these things.