### PR TITLE
Allow GuzzleFileFetcher::fetchTarget() to bypass prefixing

### DIFF
--- a/src/Client/GuzzleFileFetcher.php
+++ b/src/Client/GuzzleFileFetcher.php
@@ -86,7 +86,12 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
      */
     public function fetchTarget(string $fileName, int $maxBytes, array $options = []): PromiseInterface
     {
-        return $this->fetchFile($this->targetsPrefix . $fileName, $maxBytes, $options);
+        // If $fileName isn't a full URL, treat it as a relative path and prefix
+        // it with $this->targetsPrefix.
+        if (parse_url($fileName, PHP_URL_HOST) === null) {
+            $fileName = $this->targetsPrefix . $fileName;
+        }
+        return $this->fetchFile($fileName, $maxBytes, $options);
     }
 
     /**

--- a/src/Client/GuzzleFileFetcher.php
+++ b/src/Client/GuzzleFileFetcher.php
@@ -88,6 +88,9 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
     {
         // If $fileName isn't a full URL, treat it as a relative path and prefix
         // it with $this->targetsPrefix.
+        // @todo Revisit the need for this bypass once
+        // https://github.com/php-tuf/php-tuf/issues/128 is resolved. This was
+        // originally added because of the workaround described there.
         if (parse_url($fileName, PHP_URL_HOST) === null) {
             $fileName = $this->targetsPrefix . $fileName;
         }

--- a/tests/Unit/GuzzleFileFetcherTest.php
+++ b/tests/Unit/GuzzleFileFetcherTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7\Response;
+use PhpParser\Node\Arg;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Tuf\Client\GuzzleFileFetcher;
@@ -191,10 +192,15 @@ class GuzzleFileFetcherTest extends TestCase
         $client->requestAsync('GET', '/targets/test.txt', Argument::type('array'))
             ->willReturn($promise)
             ->shouldBeCalled();
+        // If the target is a full URL, prefixing should be bypassed.
+        $client->requestAsync('GET', 'http://example.com/test.txt', Argument::type('array'))
+            ->willReturn($promise)
+            ->shouldBeCalled();
 
         $fetcher = new GuzzleFileFetcher($client->reveal(), '/metadata/', '/targets/');
         $fetcher->fetchMetaData('root.json', 128);
         $fetcher->fetchTarget('test.txt', 128);
+        $fetcher->fetchTarget('http://example.com/test.txt', 128);
     }
 
     /**


### PR DESCRIPTION
Our plan to sign Packagist packages means that we need to be able to sign targets that live on a separate server. In order to make that work, we need to be able to pass full URLs to GuzzleFileFetcher::fetchTarget(), bypassing the prefixing that we do.