### PR TITLE
Allow targets to be downloaded from arbitrary URLs

### DIFF
--- a/src/Client/GuzzleFileFetcher.php
+++ b/src/Client/GuzzleFileFetcher.php
@@ -37,6 +37,11 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
      */
     private $targetsPrefix;
 
+    /**
+     * A map of targets to the URL from which they should be downloaded.
+     *
+     * @var array
+     */
     private $targetUrls = [];
 
     /**
@@ -75,6 +80,17 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
         return new static($client, $metaDataPrefix, $targetsPrefix);
     }
 
+    /**
+     * Maps a target to an arbitrary URL.
+     *
+     * @param string $target
+     *   The target to map.
+     * @param string|null $url
+     *   The URL from which the target should be downloaded, or null to unmap
+     *   a previously set URL.
+     *
+     * @return $this
+     */
     public function setTargetUrl(string $target, ?string $url): self
     {
         if (isset($url)) {

--- a/src/Client/GuzzleFileFetcher.php
+++ b/src/Client/GuzzleFileFetcher.php
@@ -75,9 +75,13 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
         return new static($client, $metaDataPrefix, $targetsPrefix);
     }
 
-    public function setTargetUrl(string $target, string $url): self
+    public function setTargetUrl(string $target, ?string $url): self
     {
-        $this->targetUrls[$target] = $url;
+        if (isset($url)) {
+            $this->targetUrls[$target] = $url;
+        } else {
+            unset($this->targetUrls[$target]);
+        }
         return $this;
     }
 

--- a/src/Client/GuzzleFileFetcher.php
+++ b/src/Client/GuzzleFileFetcher.php
@@ -37,6 +37,8 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
      */
     private $targetsPrefix;
 
+    private $targetUrls = [];
+
     /**
      * GuzzleFileFetcher constructor.
      *
@@ -73,6 +75,11 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
         return new static($client, $metaDataPrefix, $targetsPrefix);
     }
 
+    public function setTargetUrl(string $target, string $url): void
+    {
+        $this->targetUrls[$target] = $url;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -86,6 +93,9 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
      */
     public function fetchTarget(string $fileName, int $maxBytes, array $options = []): PromiseInterface
     {
+        if (array_key_exists($fileName, $this->targetUrls)) {
+            $fileName = $this->targetUrls[$fileName];
+        }
         // If $fileName isn't a full URL, treat it as a relative path and prefix
         // it with $this->targetsPrefix.
         // @todo Revisit the need for this bypass once

--- a/src/Client/GuzzleFileFetcher.php
+++ b/src/Client/GuzzleFileFetcher.php
@@ -144,7 +144,7 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
      *
      * @param string $fileName
      *   The file name being fetched from the remote repo.
-     * @param integer $maxBytes
+     * @param int $maxBytes
      *   The maximum number of bytes to download.
      *
      * @return \Closure

--- a/src/Client/GuzzleFileFetcher.php
+++ b/src/Client/GuzzleFileFetcher.php
@@ -111,7 +111,7 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
      *
      * @param string $url
      *   The URL of the file to fetch.
-     * @param int $maxBytes
+     * @param integer $maxBytes
      *   The maximum number of bytes to download.
      * @param array $options
      *   (optional) Additional request options to pass to the Guzzle client.
@@ -144,7 +144,7 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
      *
      * @param string $fileName
      *   The file name being fetched from the remote repo.
-     * @param int $maxBytes
+     * @param integer $maxBytes
      *   The maximum number of bytes to download.
      *
      * @return \Closure

--- a/src/Client/GuzzleFileFetcher.php
+++ b/src/Client/GuzzleFileFetcher.php
@@ -90,6 +90,7 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
      *   a previously set URL.
      *
      * @return $this
+     *   The called object.
      */
     public function setTargetUrl(string $target, ?string $url): self
     {

--- a/src/Client/GuzzleFileFetcher.php
+++ b/src/Client/GuzzleFileFetcher.php
@@ -93,16 +93,7 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
      */
     public function fetchTarget(string $fileName, int $maxBytes, array $options = [], string $url = null): PromiseInterface
     {
-        // Allow calling code to download the target from an arbitrary URL.
-        $location = $url ?? $fileName;
-        // If $location isn't a full URL, treat it as a relative path and prefix
-        // it with $this->targetsPrefix.
-        // @todo Revisit the need for this bypass once
-        // https://github.com/php-tuf/php-tuf/issues/128 is resolved. This was
-        // originally added because of the workaround described there.
-        if (parse_url($location, PHP_URL_HOST) === null) {
-            $location = $this->targetsPrefix . $location;
-        }
+        $location = $url ?: $this->targetsPrefix . $fileName;
         return $this->fetchFile($location, $maxBytes, $options);
     }
 

--- a/src/Client/GuzzleFileFetcher.php
+++ b/src/Client/GuzzleFileFetcher.php
@@ -75,9 +75,10 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
         return new static($client, $metaDataPrefix, $targetsPrefix);
     }
 
-    public function setTargetUrl(string $target, string $url): void
+    public function setTargetUrl(string $target, string $url): self
     {
         $this->targetUrls[$target] = $url;
+        return $this;
     }
 
     /**

--- a/src/Client/GuzzleFileFetcher.php
+++ b/src/Client/GuzzleFileFetcher.php
@@ -38,13 +38,6 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
     private $targetsPrefix;
 
     /**
-     * A map of targets to the URL from which they should be downloaded.
-     *
-     * @var array
-     */
-    private $targetUrls = [];
-
-    /**
      * GuzzleFileFetcher constructor.
      *
      * @param \GuzzleHttp\ClientInterface $client
@@ -81,28 +74,6 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
     }
 
     /**
-     * Maps a target to an arbitrary URL.
-     *
-     * @param string $target
-     *   The target to map.
-     * @param string|null $url
-     *   The URL from which the target should be downloaded, or null to unmap
-     *   a previously set URL.
-     *
-     * @return $this
-     *   The called object.
-     */
-    public function setTargetUrl(string $target, ?string $url): self
-    {
-        if (isset($url)) {
-            $this->targetUrls[$target] = $url;
-        } else {
-            unset($this->targetUrls[$target]);
-        }
-        return $this;
-    }
-
-    /**
      * {@inheritDoc}
      */
     public function fetchMetaData(string $fileName, int $maxBytes): PromiseInterface
@@ -113,11 +84,10 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
     /**
      * {@inheritDoc}
      */
-    public function fetchTarget(string $fileName, int $maxBytes, array $options = []): PromiseInterface
+    public function fetchTarget(string $fileName, int $maxBytes, array $options = [], string $url = null): PromiseInterface
     {
-        if (array_key_exists($fileName, $this->targetUrls)) {
-            $fileName = $this->targetUrls[$fileName];
-        }
+        // Allow calling code to download the target from an arbitrary URL.
+        $fileName = $url ?? $fileName;
         // If $fileName isn't a full URL, treat it as a relative path and prefix
         // it with $this->targetsPrefix.
         // @todo Revisit the need for this bypass once

--- a/src/Client/GuzzleFileFetcher.php
+++ b/src/Client/GuzzleFileFetcher.php
@@ -83,41 +83,59 @@ class GuzzleFileFetcher implements RepoFileFetcherInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @param array $options
+     *   (optional) Additional request options to pass to the Guzzle client.
+     *   See \GuzzleHttp\RequestOptions.
+     * @param string $url
+     *   (optional) An arbitrary URL from which the target should be downloaded.
+     *   If passed, takes precedence over $fileName.
      */
     public function fetchTarget(string $fileName, int $maxBytes, array $options = [], string $url = null): PromiseInterface
     {
         // Allow calling code to download the target from an arbitrary URL.
-        $fileName = $url ?? $fileName;
-        // If $fileName isn't a full URL, treat it as a relative path and prefix
+        $location = $url ?? $fileName;
+        // If $location isn't a full URL, treat it as a relative path and prefix
         // it with $this->targetsPrefix.
         // @todo Revisit the need for this bypass once
         // https://github.com/php-tuf/php-tuf/issues/128 is resolved. This was
         // originally added because of the workaround described there.
-        if (parse_url($fileName, PHP_URL_HOST) === null) {
-            $fileName = $this->targetsPrefix . $fileName;
+        if (parse_url($location, PHP_URL_HOST) === null) {
+            $location = $this->targetsPrefix . $location;
         }
-        return $this->fetchFile($fileName, $maxBytes, $options);
+        return $this->fetchFile($location, $maxBytes, $options);
     }
 
     /**
-     * {@inheritdoc}
+     * Fetches a file from a URL.
+     *
+     * @param string $url
+     *   The URL of the file to fetch.
+     * @param int $maxBytes
+     *   The maximum number of bytes to download.
+     * @param array $options
+     *   (optional) Additional request options to pass to the Guzzle client.
+     *   See \GuzzleHttp\RequestOptions.
+     *
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     *   A promise representing the eventual result of the operation.
      */
-    protected function fetchFile(string $fileName, int $maxBytes, array $options = []): PromiseInterface
+    protected function fetchFile(string $url, int $maxBytes, array $options = []): PromiseInterface
     {
         // Create a progress callback to abort the download if it exceeds
         // $maxBytes. This will only work with cURL, so we also verify the
         // download size when request is finished.
-        $progress = function (int $expectedBytes, int $downloadedBytes) use ($fileName, $maxBytes) {
+        $progress = function (int $expectedBytes, int $downloadedBytes) use ($url, $maxBytes) {
             if ($expectedBytes > $maxBytes || $downloadedBytes > $maxBytes) {
-                throw new DownloadSizeException("$fileName exceeded $maxBytes bytes");
+                throw new DownloadSizeException("$url exceeded $maxBytes bytes");
             }
         };
         $options += [RequestOptions::PROGRESS => $progress];
 
-        return $this->client->requestAsync('GET', $fileName, $options)
+        return $this->client->requestAsync('GET', $url, $options)
             ->then(
-                $this->onFulfilled($fileName, $maxBytes),
-                $this->onRejected($fileName)
+                $this->onFulfilled($url, $maxBytes),
+                $this->onRejected($url)
             );
     }
 

--- a/tests/Unit/GuzzleFileFetcherTest.php
+++ b/tests/Unit/GuzzleFileFetcherTest.php
@@ -207,6 +207,8 @@ class GuzzleFileFetcherTest extends TestCase
      * Tests mapping targets to arbitrary URLs.
      *
      * @covers ::setTargetUrl
+     *
+     * @return void
      */
     public function testMapping(): void
     {

--- a/tests/Unit/GuzzleFileFetcherTest.php
+++ b/tests/Unit/GuzzleFileFetcherTest.php
@@ -204,29 +204,20 @@ class GuzzleFileFetcherTest extends TestCase
     }
 
     /**
-     * Tests mapping targets to arbitrary URLs.
-     *
-     * @covers ::setTargetUrl
+     * Tests fetching a target from an arbitrary URL.
      *
      * @return void
      */
-    public function testMapping(): void
+    public function testFetchFromArbitraryUrl(): void
     {
-        $promise = new FulfilledPromise(true);
-
+        $url = 'https://example.com/test.txt';
         $client = $this->prophesize('\GuzzleHttp\ClientInterface');
-        $client->requestAsync('GET', 'https://example.com/test.txt', Argument::type('array'))
-            ->willReturn($promise)
-            ->shouldBeCalled();
-        $client->requestAsync('GET', '/targets/test.txt', Argument::type('array'))
-            ->willReturn($promise)
+        $client->requestAsync('GET', $url, Argument::type('array'))
+            ->willReturn(new FulfilledPromise(true))
             ->shouldBeCalled();
 
         $fetcher = new GuzzleFileFetcher($client->reveal(), '/metadata/', '/targets/');
-        $fetcher->setTargetUrl('test.txt', 'https://example.com/test.txt')
-            ->fetchTarget('test.txt', 128);
-        $fetcher->setTargetUrl('test.txt', null)
-            ->fetchTarget('test.txt', 128);
+        $fetcher->fetchTarget('test.txt', 128, [], $url);
     }
 
     /**

--- a/tests/Unit/GuzzleFileFetcherTest.php
+++ b/tests/Unit/GuzzleFileFetcherTest.php
@@ -203,6 +203,11 @@ class GuzzleFileFetcherTest extends TestCase
         $fetcher->fetchTarget('http://example.com/test.txt', 128);
     }
 
+    /**
+     * Tests mapping targets to arbitrary URLs.
+     *
+     * @covers ::setTargetUrl
+     */
     public function testMapping(): void
     {
         $promise = new FulfilledPromise(true);

--- a/tests/Unit/GuzzleFileFetcherTest.php
+++ b/tests/Unit/GuzzleFileFetcherTest.php
@@ -211,8 +211,8 @@ class GuzzleFileFetcherTest extends TestCase
             ->shouldBeCalled();
 
         $fetcher = new GuzzleFileFetcher($client->reveal(), '/metadata/', '/targets/');
-        $fetcher->setTargetUrl('test.txt', 'https://example.com/test.txt');
-        $fetcher->fetchTarget('test.txt', 128);
+        $fetcher->setTargetUrl('test.txt', 'https://example.com/test.txt')
+            ->fetchTarget('test.txt', 128);
     }
 
     /**

--- a/tests/Unit/GuzzleFileFetcherTest.php
+++ b/tests/Unit/GuzzleFileFetcherTest.php
@@ -192,32 +192,17 @@ class GuzzleFileFetcherTest extends TestCase
         $client->requestAsync('GET', '/targets/test.txt', Argument::type('array'))
             ->willReturn($promise)
             ->shouldBeCalled();
-        // If the target is a full URL, prefixing should be bypassed.
+        // If the target is a full URL, or an arbitrary override URL is passed,
+        // prefixing should be bypassed.
         $client->requestAsync('GET', 'http://example.com/test.txt', Argument::type('array'))
             ->willReturn($promise)
-            ->shouldBeCalled();
+            ->shouldBeCalledTimes(2);
 
         $fetcher = new GuzzleFileFetcher($client->reveal(), '/metadata/', '/targets/');
         $fetcher->fetchMetaData('root.json', 128);
         $fetcher->fetchTarget('test.txt', 128);
         $fetcher->fetchTarget('http://example.com/test.txt', 128);
-    }
-
-    /**
-     * Tests fetching a target from an arbitrary URL.
-     *
-     * @return void
-     */
-    public function testFetchFromArbitraryUrl(): void
-    {
-        $url = 'https://example.com/test.txt';
-        $client = $this->prophesize('\GuzzleHttp\ClientInterface');
-        $client->requestAsync('GET', $url, Argument::type('array'))
-            ->willReturn(new FulfilledPromise(true))
-            ->shouldBeCalled();
-
-        $fetcher = new GuzzleFileFetcher($client->reveal(), '/metadata/', '/targets/');
-        $fetcher->fetchTarget('test.txt', 128, [], $url);
+        $fetcher->fetchTarget('test.txt', 128, [], 'http://example.com/test.txt');
     }
 
     /**

--- a/tests/Unit/GuzzleFileFetcherTest.php
+++ b/tests/Unit/GuzzleFileFetcherTest.php
@@ -205,13 +205,20 @@ class GuzzleFileFetcherTest extends TestCase
 
     public function testMapping(): void
     {
+        $promise = new FulfilledPromise(true);
+
         $client = $this->prophesize('\GuzzleHttp\ClientInterface');
         $client->requestAsync('GET', 'https://example.com/test.txt', Argument::type('array'))
-            ->willReturn(new FulfilledPromise(true))
+            ->willReturn($promise)
+            ->shouldBeCalled();
+        $client->requestAsync('GET', '/targets/test.txt', Argument::type('array'))
+            ->willReturn($promise)
             ->shouldBeCalled();
 
         $fetcher = new GuzzleFileFetcher($client->reveal(), '/metadata/', '/targets/');
         $fetcher->setTargetUrl('test.txt', 'https://example.com/test.txt')
+            ->fetchTarget('test.txt', 128);
+        $fetcher->setTargetUrl('test.txt', null)
             ->fetchTarget('test.txt', 128);
     }
 

--- a/tests/Unit/GuzzleFileFetcherTest.php
+++ b/tests/Unit/GuzzleFileFetcherTest.php
@@ -203,6 +203,18 @@ class GuzzleFileFetcherTest extends TestCase
         $fetcher->fetchTarget('http://example.com/test.txt', 128);
     }
 
+    public function testMapping(): void
+    {
+        $client = $this->prophesize('\GuzzleHttp\ClientInterface');
+        $client->requestAsync('GET', 'https://example.com/test.txt', Argument::type('array'))
+            ->willReturn(new FulfilledPromise(true))
+            ->shouldBeCalled();
+
+        $fetcher = new GuzzleFileFetcher($client->reveal(), '/metadata/', '/targets/');
+        $fetcher->setTargetUrl('test.txt', 'https://example.com/test.txt');
+        $fetcher->fetchTarget('test.txt', 128);
+    }
+
     /**
      * Tests creating a file fetcher with a repo base URI.
      *


### PR DESCRIPTION
This is related to #128. It may be necessary for us to sign a package using a local copy of the file, but actually _download_ that file, in a runtime situation, from some arbitrary URL. This PR makes the GuzzleFileFetcher (and only that fetcher) support mapping a local target path to an arbitrary URL.