### PR TITLE
Make InvalidHashException aware of the offending stream

### DIFF
--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -570,7 +570,7 @@ class Updater
                 }
 
                 if ($hash !== $streamHash) {
-                    throw new InvalidHashException("Invalid $algo hash for $target");
+                    throw new InvalidHashException($stream, "Invalid $algo hash for $target");
                 }
             }
             return $stream;

--- a/src/Exception/PotentialAttackException/InvalidHashException.php
+++ b/src/Exception/PotentialAttackException/InvalidHashException.php
@@ -9,18 +9,18 @@ use Tuf\Exception\TufException;
  * Indicates an invalid hash was computed for a downloaded target.
  *
  * This exception provides access to the underlying stream which caused the
- * error. The stream's contents are NOT trusted by TUF, so any code which
- * interacts with this exception, or the stream, should do so with great caution
- * and treat the stream contents as unsafe.
+ * error. The stream's contents have failed TUF validation, so any code which
+ * interacts with the stream should do so with great caution and treat its
+ * contents as unsafe.
  */
 class InvalidHashException extends TufException
 {
     /**
      * An untrusted stream object pointing to the downloaded target.
      *
-     * WARNING: The contents of the stream are NOT trusted by TUF! Any code
-     * interacting with this exception, or the underlying stream, should proceed
-     * with great caution.
+     * WARNING: The contents of the stream failed TUF validation. Any code
+     * interacting with this stream, should treat it as unsafe and proceed with
+     * great caution.
      *
      * @var \Psr\Http\Message\StreamInterface
      */
@@ -31,8 +31,9 @@ class InvalidHashException extends TufException
      *
      * @param \Psr\Http\Message\StreamInterface $stream
      *   An untrusted stream object pointing to the downloaded target. The
-     *   contents of this stream are NOT trusted by TUF! Any code interacting
-     *   with this exception, or this stream, should proceed with great caution.
+     *   contents of this stream have failed TUF validation, so any code
+     *   interacting with it should treat it as unsafe and proceed with great
+     *   caution.
      * @param string $message
      *   (optional) The exception message.
      * @param int $code
@@ -49,9 +50,8 @@ class InvalidHashException extends TufException
     /**
      * Returns the untrusted stream object pointing to the downloaded target.
      *
-     * WARNING: The contents of the stream are NOT trusted by TUF! Any code
-     * interacting with this exception, or the underlying stream, should proceed
-     * with great caution.
+     * WARNING: The contents of the stream failed TUF validation. Any code
+     * interacting it should treat it as unsafe and proceed with great caution.
      *
      * @return \Psr\Http\Message\StreamInterface
      *   The stream object.

--- a/src/Exception/PotentialAttackException/InvalidHashException.php
+++ b/src/Exception/PotentialAttackException/InvalidHashException.php
@@ -2,6 +2,7 @@
 
 namespace Tuf\Exception\PotentialAttackException;
 
+use Psr\Http\Message\StreamInterface;
 use Tuf\Exception\TufException;
 
 /**
@@ -9,4 +10,39 @@ use Tuf\Exception\TufException;
  */
 class InvalidHashException extends TufException
 {
+    /**
+     * A stream object pointing to the downloaded target.
+     *
+     * @var \Psr\Http\Message\StreamInterface
+     */
+    private $stream;
+
+    /**
+     * InvalidHashException constructor.
+     *
+     * @param \Psr\Http\Message\StreamInterface $stream
+     *   A stream object pointing to the downloaded target.
+     * @param string $message
+     *   (optional) The exception message.
+     * @param int $code
+     *   (optional) The exception code.
+     * @param \Throwable|null $previous
+     *   The previous exception, if any.
+     */
+    public function __construct(StreamInterface $stream, $message = "", $code = 0, \Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->stream = $stream;
+    }
+
+    /**
+     * Returns the stream object pointing to the downloaded target.
+     *
+     * @return \Psr\Http\Message\StreamInterface
+     *   The stream object.
+     */
+    public function getStream(): StreamInterface
+    {
+        return $this->stream;
+    }
 }

--- a/src/Exception/PotentialAttackException/InvalidHashException.php
+++ b/src/Exception/PotentialAttackException/InvalidHashException.php
@@ -19,7 +19,7 @@ class InvalidHashException extends TufException
      * An untrusted stream object pointing to the downloaded target.
      *
      * WARNING: The contents of the stream failed TUF validation. Any code
-     * interacting with this stream, should treat it as unsafe and proceed with
+     * interacting with this stream should treat it as unsafe and proceed with
      * great caution.
      *
      * @var \Psr\Http\Message\StreamInterface

--- a/src/Exception/PotentialAttackException/InvalidHashException.php
+++ b/src/Exception/PotentialAttackException/InvalidHashException.php
@@ -11,7 +11,11 @@ use Tuf\Exception\TufException;
 class InvalidHashException extends TufException
 {
     /**
-     * A stream object pointing to the downloaded target.
+     * An untrusted stream object pointing to the downloaded target.
+     *
+     * WARNING: The contents of the stream are NOT trusted by TUF! Any code
+     * interacting with this exception, or the underlying stream, should proceed
+     * with great caution.
      *
      * @var \Psr\Http\Message\StreamInterface
      */
@@ -21,7 +25,9 @@ class InvalidHashException extends TufException
      * InvalidHashException constructor.
      *
      * @param \Psr\Http\Message\StreamInterface $stream
-     *   A stream object pointing to the downloaded target.
+     *   An untrusted stream object pointing to the downloaded target. The
+     *   contents of this stream are NOT trusted by TUF! Any code interacting
+     *   with this exception, or this stream, should proceed with great caution.
      * @param string $message
      *   (optional) The exception message.
      * @param int $code
@@ -36,7 +42,11 @@ class InvalidHashException extends TufException
     }
 
     /**
-     * Returns the stream object pointing to the downloaded target.
+     * Returns the untrusted stream object pointing to the downloaded target.
+     *
+     * WARNING: The contents of the stream are NOT trusted by TUF! Any code
+     * interacting with this exception, or the underlying stream, should proceed
+     * with great caution.
      *
      * @return \Psr\Http\Message\StreamInterface
      *   The stream object.

--- a/src/Exception/PotentialAttackException/InvalidHashException.php
+++ b/src/Exception/PotentialAttackException/InvalidHashException.php
@@ -7,6 +7,11 @@ use Tuf\Exception\TufException;
 
 /**
  * Indicates an invalid hash was computed for a downloaded target.
+ *
+ * This exception provides access to the underlying stream which caused the
+ * error. The stream's contents are NOT trusted by TUF, so any code which
+ * interacts with this exception, or the stream, should do so with great caution
+ * and treat the stream contents as unsafe.
  */
 class InvalidHashException extends TufException
 {

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -139,12 +139,11 @@ class UpdaterTest extends TestCase
         $this->testRepo->repoFilesContents['testtarget.txt'] = new FulfilledPromise($stream);
         try {
             $updater->download('testtarget.txt')->wait();
+            $this->fail('Expected InvalidHashException to be thrown, but it was not.');
         } catch (InvalidHashException $e) {
             $this->assertSame("Invalid sha256 hash for testtarget.txt", $e->getMessage());
             $this->assertSame($stream, $e->getStream());
-            return;
         }
-        $this->fail('Expected InvalidHashException to be thrown, but it was not.');
     }
 
     /**


### PR DESCRIPTION
In order to get around the fact that the Composer integration plugin doesn't handle 304 responses, we need to be able to convert an InvalidHashException caused by a 304 to a legitimate response object. In order to do *that*, we need some way for calling code to access the stream that caused the InvalidHashException. This PR adds such an accessor.