### PR TITLE
Stop using deep_copy() function

### DIFF
--- a/src/KeyDB.php
+++ b/src/KeyDB.php
@@ -3,10 +3,9 @@
 
 namespace Tuf;
 
-use Tuf\Exception\FormatException;
+use DeepCopy\DeepCopy;
 use Tuf\Exception\NotFoundException;
 use Tuf\Metadata\RootMetadata;
-use function DeepCopy\deep_copy;
 
 /**
  * Represent a collection of keys and their organization.
@@ -165,6 +164,6 @@ class KeyDB
         if (empty($this->keys[$keyId])) {
             throw new NotFoundException($keyId, 'key');
         }
-        return deep_copy($this->keys[$keyId]);
+        return (new DeepCopy())->copy($this->keys[$keyId]);
     }
 }

--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -2,6 +2,7 @@
 
 namespace Tuf\Metadata;
 
+use DeepCopy\DeepCopy;
 use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\Count;
@@ -14,7 +15,6 @@ use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Component\Validator\Validation;
 use Tuf\Exception\MetadataException;
 use Tuf\JsonNormalizer;
-use function DeepCopy\deep_copy;
 
 /**
  * Base class for metadata.
@@ -185,7 +185,7 @@ abstract class MetadataBase
      */
     public function getSigned():\ArrayObject
     {
-        return deep_copy($this->metaData['signed']);
+        return (new DeepCopy())->copy($this->metaData['signed']);
     }
 
     /**
@@ -218,7 +218,7 @@ abstract class MetadataBase
      */
     public function getSignatures() : array
     {
-        return deep_copy($this->metaData['signatures']);
+        return (new DeepCopy())->copy($this->metaData['signatures']);
     }
 
     /**


### PR DESCRIPTION
For whatever reason, in some circumstances Composer seems to have a problem resolving the deep_copy() function. It looks like it's a pretty thin wrapper anyway; I propose we use the class reference directly.