### PR TITLE
TargetsMetadata should throw a TUF-specific exception for undefined targets

### DIFF
--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Promise\RejectedPromise;
 use Psr\Http\Message\StreamInterface;
 use Tuf\Client\DurableStorage\DurableStorageAccessValidator;
 use Tuf\Exception\FormatException;
+use Tuf\Exception\NotFoundException;
 use Tuf\Exception\PotentialAttackException\DenialOfServiceAttackException;
 use Tuf\Exception\PotentialAttackException\FreezeAttackException;
 use Tuf\Exception\PotentialAttackException\InvalidHashException;
@@ -546,7 +547,7 @@ class Updater
         // immediately return a rejected promise.
         try {
             $hashes = $targetsMetaData->getHashes($target);
-        } catch (\InvalidArgumentException $e) {
+        } catch (NotFoundException $e) {
             return new RejectedPromise($e);
         }
 

--- a/src/Metadata/TargetsMetadata.php
+++ b/src/Metadata/TargetsMetadata.php
@@ -8,6 +8,7 @@ use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Required;
 use Symfony\Component\Validator\Constraints\Type;
+use Tuf\Exception\NotFoundException;
 
 class TargetsMetadata extends MetadataBase
 {
@@ -104,7 +105,7 @@ class TargetsMetadata extends MetadataBase
      * @return \ArrayObject
      *   The target's info.
      *
-     * @throws \InvalidArgumentException
+     * @throws \Tuf\Exception\NotFoundException
      *   Thrown if the target is not mentioned in this metadata.
      */
     protected function getInfo(string $target): \ArrayObject
@@ -113,6 +114,6 @@ class TargetsMetadata extends MetadataBase
         if (isset($signed['targets'][$target])) {
             return $signed['targets'][$target];
         }
-        throw new \InvalidArgumentException("Unknown target: '$target'");
+        throw new NotFoundException($target, 'Target');
     }
 }

--- a/tests/Metadata/TargetsMetadataTest.php
+++ b/tests/Metadata/TargetsMetadataTest.php
@@ -2,6 +2,7 @@
 
 namespace Tuf\Tests\Metadata;
 
+use Tuf\Exception\NotFoundException;
 use Tuf\Metadata\MetadataBase;
 use Tuf\Metadata\TargetsMetadata;
 
@@ -48,15 +49,15 @@ class TargetsMetadataTest extends MetaDataBaseTest
         try {
             $metadata->getHashes('void.txt');
             $this->fail('Exception was not thrown for an invalid target.');
-        } catch (\InvalidArgumentException $e) {
-            $this->assertSame("Unknown target: 'void.txt'", $e->getMessage());
+        } catch (NotFoundException $e) {
+            $this->assertSame("Target not found: void.txt", $e->getMessage());
         }
 
         try {
             $metadata->getLength('void.txt');
             $this->fail('Exception was not thrown for an invalid target.');
-        } catch (\InvalidArgumentException $e) {
-            $this->assertSame("Unknown target: 'void.txt'", $e->getMessage());
+        } catch (NotFoundException $e) {
+            $this->assertSame("Target not found: void.txt", $e->getMessage());
         }
     }
 


### PR DESCRIPTION
Right now, if the updater requests metadata about a specific target and that target is unknown, we throw InvalidArgumentException. Although that technically works, it's very ambiguous to the calling code; it has no real way to know that the exception was thrown by TUF, for TUF-specific reasons. We should use our already-existing NotFoundException instead, which will be a lot clearer to consumers of TUF.