### PR TITLE
Update NotFoundException default item type

### DIFF
--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -21,7 +21,7 @@ class NotFoundException extends TufException
      * @param \Throwable|null $previous
      *     (optional) The previous exception, if any, for exception chaining.
      */
-    public function __construct(string $key = '', string $itemType = 'item', \Throwable $previous = null)
+    public function __construct(string $key = '', string $itemType = 'Item', \Throwable $previous = null)
     {
         $message = "$itemType not found";
         if ($key != "") {


### PR DESCRIPTION
Since `$itemType` is printed as the first word in a clause (~sentence), the default value should be capitalized.