### PR TITLE
Allow 'custom' element on target metadata

### DIFF
--- a/src/Metadata/TargetsMetadata.php
+++ b/src/Metadata/TargetsMetadata.php
@@ -62,7 +62,7 @@ class TargetsMetadata extends MetadataBase
                         new GreaterThanOrEqual(1),
                     ],
                     'custom' => new Optional([
-                      new Type('\ArrayObject'),
+                        new Type('\ArrayObject'),
                     ]),
                 ] + static::getHashesConstraints()),
             ]),

--- a/src/Metadata/TargetsMetadata.php
+++ b/src/Metadata/TargetsMetadata.php
@@ -6,6 +6,7 @@ use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Optional;
 use Symfony\Component\Validator\Constraints\Required;
 use Symfony\Component\Validator\Constraints\Type;
 use Tuf\Exception\NotFoundException;
@@ -60,6 +61,9 @@ class TargetsMetadata extends MetadataBase
                         new Type(['type' => 'integer']),
                         new GreaterThanOrEqual(1),
                     ],
+                    'custom' => new Optional([
+                      new Type('\ArrayObject'),
+                    ]),
                 ] + static::getHashesConstraints()),
             ]),
 

--- a/tests/Metadata/MetaDataBaseTest.php
+++ b/tests/Metadata/MetaDataBaseTest.php
@@ -277,12 +277,15 @@ abstract class MetaDataBaseTest extends TestCase
             case 'boolean':
                 $newValue = 'this is a string';
                 break;
+            case '\ArrayObject':
+                $newValue = 'Not an ArrayObject';
+                break;
         }
 
         $this->nestedChange($keys, $metadata, $newValue);
         $json = json_encode($metadata);
         $this->expectException(MetadataException::class);
-        $this->expectExceptionMessageMatches("/This value should be of type $expectedType/s");
+        $this->expectExceptionMessageMatches("/This value should be of type " . preg_quote($expectedType) . "/s");
         static::callCreateFromJson($json);
     }
 

--- a/tests/Metadata/TargetsMetadataTest.php
+++ b/tests/Metadata/TargetsMetadataTest.php
@@ -110,6 +110,4 @@ class TargetsMetadataTest extends MetaDataBaseTest
         $data[] = ["signed:targets:$target:custom", ['ignored_key' => 'ignored_value']];
         return $data;
     }
-
-
 }

--- a/tests/Metadata/TargetsMetadataTest.php
+++ b/tests/Metadata/TargetsMetadataTest.php
@@ -96,6 +96,20 @@ class TargetsMetadataTest extends MetaDataBaseTest
         $target = $this->getFixtureNestedArrayFirstKey($this->validJson, ['signed', 'targets']);
         $data[] = ["signed:targets:$target:hashes", 'array'];
         $data[] = ["signed:targets:$target:length", 'int'];
+        $data[] = ["signed:targets:$target:custom", '\ArrayObject'];
         return $data;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function providerOptionalFields(): array
+    {
+        $data = parent::providerOptionalFields();
+        $target = $this->getFixtureNestedArrayFirstKey($this->validJson, ['signed', 'targets']);
+        $data[] = ["signed:targets:$target:custom", ['ignored_key' => 'ignored_value']];
+        return $data;
+    }
+
+
 }


### PR DESCRIPTION
'custom' is allowed for targets but is ignored by the spec https://github.com/theupdateframework/specification/blob/v1.0.9/tuf-spec.md