### PR TITLE
Adds getRole method 

### DIFF
--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -339,13 +339,13 @@ class Updater
     {
         $signatures = $metaData->getSignatures();
 
-        $roleInfo = $this->roleDB->getRoleInfo($metaData->getType());
+        $roleInfo = $this->roleDB->getRoleInfo($metaData->getRole());
         $needVerified = $roleInfo['threshold'];
         $haveVerified = 0;
 
         $canonicalBytes = JsonNormalizer::asNormalizedJson($metaData->getSigned());
         foreach ($signatures as $signature) {
-            if ($this->isKeyIdAcceptableForRole($signature['keyid'], $metaData->getType())) {
+            if ($this->isKeyIdAcceptableForRole($signature['keyid'], $metaData->getRole())) {
                 $haveVerified += (int) $this->verifySingleSignature($canonicalBytes, $signature);
             }
             // @todo Determine if we should check all signatures and warn for
@@ -357,7 +357,7 @@ class Updater
         }
 
         if ($haveVerified < $needVerified) {
-            throw new SignatureThresholdExpception("Signature threshold not met on " . $metaData->getType());
+            throw new SignatureThresholdExpception("Signature threshold not met on " . $metaData->getRole());
         }
     }
 

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -320,7 +320,7 @@ class Updater
         $metadataExpiration = static::metadataTimestampToDatetime($metadata->getExpires());
         if ($metadataExpiration < $now) {
             $format = "Remote %s metadata expired on %s";
-            throw new FreezeAttackException(sprintf($format, $metadata->getType(), $metadataExpiration->format('c')));
+            throw new FreezeAttackException(sprintf($format, $metadata->getRole(), $metadataExpiration->format('c')));
         }
     }
 

--- a/src/Metadata/MetaFileInfoTrait.php
+++ b/src/Metadata/MetaFileInfoTrait.php
@@ -42,16 +42,17 @@ trait MetaFileInfoTrait
     public function verifyNewMetaData(MetadataBase $newMetadata):void
     {
         $this->ensureIsTrusted();
-        $fileInfo = $this->getFileMetaInfo($newMetadata->getType() . '.json');
+        $role = $newMetadata->getRole();
+        $fileInfo = $this->getFileMetaInfo($role . '.json');
         $expectedVersion = $fileInfo['version'];
         if ($expectedVersion !== $newMetadata->getVersion()) {
-            throw new MetadataException("Expected {$newMetadata->getType()} version {$expectedVersion} does not match actual version {$newMetadata->getVersion()}.");
+            throw new MetadataException("Expected {$role} version {$expectedVersion} does not match actual version {$newMetadata->getVersion()}.");
         }
         if (isset($fileInfo['hashes'])) {
             foreach ($fileInfo['hashes'] as $algo => $hash) {
                 if ($hash !== hash($algo, $newMetadata->getSource())) {
                     /** @var \Tuf\Metadata\MetadataBase $authorityMetadata */
-                    throw new MetadataException("The '{$newMetadata->getType()}' contents does not match hash '$algo' specified in the '{$this->getType()}' metadata.");
+                    throw new MetadataException("The '{$role}' contents does not match hash '$algo' specified in the '{$this->getType()}' metadata.");
                 }
             }
         }

--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -233,6 +233,20 @@ abstract class MetadataBase
     }
 
     /**
+     * Gets the role for the metadata.
+     *
+     * @return string
+     *   The type.
+     */
+    public function getRole() : string
+    {
+        // For most metadata types the 'type' and the 'role' are the same.
+        // Metadata types that need to specify a different role should override
+        // this method.
+        return $this->getType();
+    }
+
+    /**
      * @return boolean
      *    Whether the metadata is trusted.
      */

--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -277,7 +277,7 @@ abstract class MetadataBase
     protected function ensureIsTrusted(bool $allowUntrustedAccess = false): void
     {
         if (!$allowUntrustedAccess && !$this->isTrusted()) {
-            throw new \RuntimeException("Cannot use untrusted '{$this->getType()}'. metadata.");
+            throw new \RuntimeException("Cannot use untrusted '{$this->getRole()}'. metadata.");
         }
     }
 }

--- a/src/Metadata/TargetsMetadata.php
+++ b/src/Metadata/TargetsMetadata.php
@@ -32,7 +32,7 @@ class TargetsMetadata extends MetadataBase
      * @param string|null $roleName
      *   The role name if not the same as the type.
      */
-    public static function createFromJson(string $json, ?string $roleName = null)
+    public static function createFromJson(string $json, string $roleName = null)
     {
         $newMetadata = parent::createFromJson($json);
         $newMetadata->role = $roleName;

--- a/src/Metadata/TargetsMetadata.php
+++ b/src/Metadata/TargetsMetadata.php
@@ -20,6 +20,26 @@ class TargetsMetadata extends MetadataBase
     protected const TYPE = 'targets';
 
     /**
+     * The role name if different from the type.
+     *
+     * @var string
+     */
+    private $role;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param string|null $roleName
+     *   The role name if not the same as the type.
+     */
+    public static function createFromJson(string $json, ?string $roleName = null)
+    {
+        $newMetadata = parent::createFromJson($json);
+        $newMetadata->role = $roleName;
+        return $newMetadata;
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected static function getSignedCollectionOptions(): array
@@ -83,6 +103,14 @@ class TargetsMetadata extends MetadataBase
     public function getLength(string $target): int
     {
         return $this->getInfo($target)['length'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRole(): string
+    {
+        return $this->role ?? $this->getType();
     }
 
     /**

--- a/tests/Metadata/MetaDataBaseTest.php
+++ b/tests/Metadata/MetaDataBaseTest.php
@@ -110,6 +110,24 @@ abstract class MetaDataBaseTest extends TestCase
     }
 
     /**
+     * @covers ::getType
+     */
+    public function testGetType()
+    {
+        $metadata = static::callCreateFromJson($this->localRepo[$this->validJson]);
+        $this->assertSame($metadata->getType(), $this->expectedType);
+    }
+
+    /**
+     * @covers ::getRole
+     */
+    public function testGetRole()
+    {
+        $metadata = static::callCreateFromJson($this->localRepo[$this->validJson]);
+        $this->assertSame($this->expectedType, $metadata->getRole());
+    }
+
+    /**
      * Tests valid and invalid expires dates.
      *
      * @param string $expires

--- a/tests/Metadata/TargetsMetadataTest.php
+++ b/tests/Metadata/TargetsMetadataTest.php
@@ -23,9 +23,9 @@ class TargetsMetadataTest extends MetaDataBaseTest
     /**
      * {@inheritdoc}
      */
-    protected static function callCreateFromJson(string $json) : MetadataBase
+    protected static function callCreateFromJson(string $json, string $role = null) : MetadataBase
     {
-        return TargetsMetadata::createFromJson($json);
+        return TargetsMetadata::createFromJson($json, $role);
     }
 
     /**
@@ -109,5 +109,16 @@ class TargetsMetadataTest extends MetaDataBaseTest
         $target = $this->getFixtureNestedArrayFirstKey($this->validJson, ['signed', 'targets']);
         $data[] = ["signed:targets:$target:custom", ['ignored_key' => 'ignored_value']];
         return $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testGetRole()
+    {
+        parent::testGetRole();
+        // Confirm that if a role name is specified this will be returned.
+        $metadata = static::callCreateFromJson($this->localRepo[$this->validJson], 'other_role');
+        $this->assertSame('other_role', $metadata->getRole());
     }
 }


### PR DESCRIPTION
Role is not always the same as type. Delegate roles will be the type targets' but role specified in the delegation.