### PR TITLE
Updater should validate the length of a downloaded stream

### DIFF
--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -560,6 +560,8 @@ class Updater
                 throw $error;
             }
         } else {
+            // @todo Handle non-seekable streams.
+            $data->rewind();
             $data->read($maxBytes);
 
             // If we reached the end of the stream, we didn't exceed the
@@ -567,7 +569,6 @@ class Updater
             if ($data->eof() === false) {
                 throw $error;
             }
-            // @todo Handle non-seekable streams with unknown size.
             $data->rewind();
         }
     }

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\RejectedPromise;
 use Psr\Http\Message\StreamInterface;
 use Tuf\Client\DurableStorage\DurableStorageAccessValidator;
+use Tuf\Exception\DownloadSizeException;
 use Tuf\Exception\FormatException;
 use Tuf\Exception\NotFoundException;
 use Tuf\Exception\PotentialAttackException\DenialOfServiceAttackException;
@@ -528,7 +529,47 @@ class Updater
      */
     private function fetchFile(string $fileName, int $maxBytes = self::MAXIMUM_DOWNLOAD_BYTES): string
     {
-        return $this->repoFileFetcher->fetchMetaData($fileName, $maxBytes)->wait();
+        return $this->repoFileFetcher->fetchMetaData($fileName, $maxBytes)
+            ->then(function (StreamInterface $data) use ($fileName, $maxBytes) {
+                $this->checkLength($data, $maxBytes, $fileName);
+                return $data;
+            })
+            ->wait();
+    }
+
+    /**
+     * Verifies the length of a data stream.
+     *
+     * @param \Psr\Http\Message\StreamInterface $data
+     *   The data stream to check.
+     * @param int $maxBytes
+     *   The maximum acceptable length of the stream, in bytes.
+     * @param string $fileName
+     *   The filename associated with the stream.
+     *
+     * @throws \Tuf\Exception\DownloadSizeException
+     *   If the stream's length exceeds $maxBytes in size.
+     */
+    private function checkLength(StreamInterface $data, int $maxBytes, string $fileName): void
+    {
+        $error = new DownloadSizeException("$fileName exceeded $maxBytes bytes");
+        $size = $data->getSize();
+
+        if (isset($size)) {
+            if ($size > $maxBytes) {
+                throw $error;
+            }
+        } else {
+            $data->read($maxBytes);
+
+            // If we reached the end of the stream, we didn't exceed the
+            // maximum number of bytes.
+            if ($data->eof() === false) {
+                throw $error;
+            }
+            // @todo Handle non-seekable streams with unknown size.
+            $data->rewind();
+        }
     }
 
     /**
@@ -567,7 +608,9 @@ class Updater
         }
         $length = $targetsMetaData->getLength($target) ?? static::MAXIMUM_DOWNLOAD_BYTES;
 
-        $verify = function (StreamInterface $stream) use ($target, $hashes) {
+        $verify = function (StreamInterface $stream) use ($target, $hashes, $length) {
+            $this->checkLength($stream, $length, $target);
+
             foreach ($hashes as $algo => $hash) {
                 // If the stream has a URI that refers to a file, use
                 // hash_file() to verify it. Otherwise, read the entire stream

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 use Tuf\Client\Updater;
+use Tuf\Exception\DownloadSizeException;
 use Tuf\Exception\MetadataException;
 use Tuf\Exception\PotentialAttackException\InvalidHashException;
 use Tuf\Exception\PotentialAttackException\RollbackAttackException;
@@ -128,6 +129,7 @@ class UpdaterTest extends TestCase
         $stream->getMetadata('uri')->willReturn($testFilePath);
         $stream->getContents()->shouldNotBeCalled();
         $stream->rewind()->shouldNotBeCalled();
+        $stream->getSize()->willReturn(strlen($testFileContents));
         $this->testRepo->repoFilesContents['testtarget.txt'] = new FulfilledPromise($stream->reveal());
         $updater->download('testtarget.txt')->wait();
 
@@ -143,6 +145,30 @@ class UpdaterTest extends TestCase
         } catch (InvalidHashException $e) {
             $this->assertSame("Invalid sha256 hash for testtarget.txt", $e->getMessage());
             $this->assertSame($stream, $e->getStream());
+        }
+
+        // If the stream is longer than expected, we should get an exception,
+        // whether or not the stream's length is known.
+        $stream = $stream = $this->prophesize('\Psr\Http\Message\StreamInterface');
+        $stream->getSize()->willReturn(1024);
+        $this->testRepo->repoFilesContents['testtarget.txt'] = new FulfilledPromise($stream->reveal());
+        try {
+            $updater->download('testtarget.txt')->wait();
+            $this->fail('Expected DownloadSizeException to be thrown, but it was not.');
+        } catch (DownloadSizeException $e) {
+            $this->assertSame("testtarget.txt exceeded 24 bytes", $e->getMessage());
+        }
+
+        $stream = $stream = $this->prophesize('\Psr\Http\Message\StreamInterface');
+        $stream->getSize()->willReturn(null);
+        $stream->read(24)->willReturn('A nice, long string that is certainly longer than 24 bytes.');
+        $stream->eof()->willReturn(false);
+        $this->testRepo->repoFilesContents['testtarget.txt'] = new FulfilledPromise($stream->reveal());
+        try {
+            $updater->download('testtarget.txt')->wait();
+            $this->fail('Expected DownloadSizeException to be thrown, but it was not.');
+        } catch (DownloadSizeException $e) {
+            $this->assertSame("testtarget.txt exceeded 24 bytes", $e->getMessage());
         }
     }
 

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -161,6 +161,7 @@ class UpdaterTest extends TestCase
 
         $stream = $stream = $this->prophesize('\Psr\Http\Message\StreamInterface');
         $stream->getSize()->willReturn(null);
+        $stream->rewind()->shouldBeCalledOnce();
         $stream->read(24)->willReturn('A nice, long string that is certainly longer than 24 bytes.');
         $stream->eof()->willReturn(false);
         $this->testRepo->repoFilesContents['testtarget.txt'] = new FulfilledPromise($stream->reveal());

--- a/tests/Unit/GuzzleFileFetcherTest.php
+++ b/tests/Unit/GuzzleFileFetcherTest.php
@@ -84,7 +84,6 @@ class GuzzleFileFetcherTest extends TestCase
             [404, RepoFileNotFound::class, 0],
             [403, 'RuntimeException'],
             [500, BadResponseException::class],
-            [200, DownloadSizeException::class, 0, 4],
         ];
     }
 
@@ -99,7 +98,6 @@ class GuzzleFileFetcherTest extends TestCase
         return [
             [403, 'RuntimeException'],
             [500, BadResponseException::class],
-            [200, DownloadSizeException::class, 0, 4],
         ];
     }
 


### PR DESCRIPTION
Right now, it's up to the file fetchers to validate the length of the data they retrieve. Since bounds checking is important in TUF, this is something that the Updater should do itself, by acting on the streams returned from the file fetchers.