### PR TITLE
Add helper methods to get delegated info

### DIFF
--- a/src/Metadata/TargetsMetadata.php
+++ b/src/Metadata/TargetsMetadata.php
@@ -120,4 +120,26 @@ class TargetsMetadata extends MetadataBase
         }
         throw new NotFoundException($target, 'Target');
     }
+
+    /**
+     * Gets the delegated keys if any.
+     *
+     * @return \ArrayObject
+     *   The delegated keys.
+     */
+    public function getDelegatedKeys(): \ArrayObject
+    {
+        return $this->getSigned()['delegations']['keys'] ?? new \ArrayObject([]);
+    }
+
+    /**
+     * Gets the delegated roles if any.
+     *
+     * @return \ArrayObject[]
+     *   The delegated roles.
+     */
+    public function getDelegatedRoles(): array
+    {
+        return $this->getSigned()['delegations']['roles'] ?? [];
+    }
 }

--- a/tests/Metadata/TargetsMetadataTest.php
+++ b/tests/Metadata/TargetsMetadataTest.php
@@ -6,6 +6,9 @@ use Tuf\Exception\NotFoundException;
 use Tuf\Metadata\MetadataBase;
 use Tuf\Metadata\TargetsMetadata;
 
+/**
+ * @coversDefaultClass \Tuf\Metadata\TargetsMetadata
+ */
 class TargetsMetadataTest extends MetaDataBaseTest
 {
 
@@ -109,5 +112,31 @@ class TargetsMetadataTest extends MetaDataBaseTest
         $target = $this->getFixtureNestedArrayFirstKey($this->validJson, ['signed', 'targets']);
         $data[] = ["signed:targets:$target:custom", ['ignored_key' => 'ignored_value']];
         return $data;
+    }
+
+    /**
+     * @covers ::getDelegatedKeys
+     */
+    public function testGetDelegatedKeys(): void
+    {
+        $json = $this->localRepo[$this->validJson];
+        $metadata = TargetsMetadata::createFromJson($json);
+        $json = json_decode($json, true);
+        $keys = $metadata->getDelegatedKeys();
+        static::replaceArrayObjects($keys);
+        $this->assertSame($json['signed']['delegations']['keys'], $keys);
+    }
+
+    /**
+     * @covers ::getDelegatedRoles
+     */
+    public function testGetDelegatedRoles(): void
+    {
+        $json = $this->localRepo[$this->validJson];
+        $metadata = TargetsMetadata::createFromJson($json);
+        $json = json_decode($json, true);
+        $keys = $metadata->getDelegatedRoles();
+        static::replaceArrayObjects($keys);
+        $this->assertSame($json['signed']['delegations']['roles'], $keys);
     }
 }

--- a/tests/TestHelpers/UtilsTrait.php
+++ b/tests/TestHelpers/UtilsTrait.php
@@ -88,4 +88,22 @@ trait UtilsTrait
             $data[$key] = $newValue;
         }
     }
+
+    /**
+     * Replaces all ArrayObject instances with arrays to allow comparison.
+     *
+     * @param $data
+     *    The data to replace.
+     */
+    protected static function replaceArrayObjects(&$data): void
+    {
+        if ($data instanceof \ArrayObject) {
+            $data = $data->getArrayCopy();
+        }
+        if (is_array($data) || $data instanceof \ArrayObject) {
+            foreach ($data as &$value) {
+                static::replaceArrayObjects($value);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Adds TargetsMetadata::getDelegatedKeys() and TargetsMetadata::getDelegatedRoles()