### PR TITLE
Refactor verifying target metadata file into method

### DIFF
--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -216,18 +216,7 @@ class Updater
 
         // TUF-SPEC-v1.0.9 Section 5.4
         if ($rootData->supportsConsistentSnapshots()) {
-            $targetsVersion = $newSnapshotData->getFileMetaInfo('targets.json')['version'];
-            $newTargetsContent = $this->fetchFile("$targetsVersion.targets.json");
-            $newTargetsData = TargetsMetadata::createFromJson($newTargetsContent);
-            // TUF-SPEC-v1.0.9 Section 5.4.1
-            $newSnapshotData->verifyNewMetaData($newTargetsData);
-            // TUF-SPEC-v1.0.9 Section 5.4.2
-            $this->checkSignatures($newTargetsData);
-            // TUF-SPEC-v1.0.9 Section 5.4.3
-            static::checkFreezeAttack($newTargetsData, $nowDate);
-            $newTargetsData->setIsTrusted(true);
-            // TUF-SPEC-v1.0.9 Section 5.4.4
-            $this->durableStorage['targets.json'] = $newTargetsContent;
+            $this->fetchAndVerifyTargetMetadata('targets');
         } else {
             throw new \UnexpectedValueException("Currently only repos using consistent snapshots are supported.");
         }
@@ -656,5 +645,31 @@ class Updater
                 $this->verify($target, $stream);
                 return $stream;
             });
+    }
+
+    /**
+     * @param \Tuf\Metadata\SnapshotMetadata $newSnapshotData
+     * @param \DateTimeImmutable $nowDate
+     *
+     * @throws \Tuf\Exception\MetadataException
+     * @throws \Tuf\Exception\PotentialAttackException\FreezeAttackException
+     * @throws \Tuf\Exception\PotentialAttackException\SignatureThresholdExpception
+     */
+    protected function fetchAndVerifyTargetMetadata(string $role): TargetsMetadata {
+        $newSnapshotData = SnapshotMetadata::createFromJson($this->durableStorage['snapshot.json']);
+        $newSnapshotData->setIsTrusted(true);
+        $targetsVersion = $newSnapshotData->getFileMetaInfo("$role.json")['version'];
+        $newTargetsContent = $this->fetchFile("$targetsVersion.$role.json");
+        $newTargetsData = TargetsMetadata::createFromJson($newTargetsContent);
+        // TUF-SPEC-v1.0.9 Section 5.4.1
+        $newSnapshotData->verifyNewMetaData($newTargetsData);
+        // TUF-SPEC-v1.0.9 Section 5.4.2
+        $this->checkSignatures($newTargetsData);
+        // TUF-SPEC-v1.0.9 Section 5.4.3
+        static::checkFreezeAttack($newTargetsData, $this->getCurrentTime());
+        $newTargetsData->setIsTrusted(true);
+        // TUF-SPEC-v1.0.9 Section 5.4.4
+        $this->durableStorage["$role.json"] = $newTargetsContent;
+        return $newTargetsData;
     }
 }

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -216,7 +216,7 @@ class Updater
 
         // TUF-SPEC-v1.0.9 Section 5.4
         if ($rootData->supportsConsistentSnapshots()) {
-            $this->fetchAndVerifyTargetMetadata('targets');
+            $this->fetchAndVerifyTargetsMetadata('targets');
         } else {
             throw new \UnexpectedValueException("Currently only repos using consistent snapshots are supported.");
         }
@@ -648,14 +648,15 @@ class Updater
     }
 
     /**
-     * @param \Tuf\Metadata\SnapshotMetadata $newSnapshotData
-     * @param \DateTimeImmutable $nowDate
+     * Fetches and verifies a targets metadata file.
      *
-     * @throws \Tuf\Exception\MetadataException
-     * @throws \Tuf\Exception\PotentialAttackException\FreezeAttackException
-     * @throws \Tuf\Exception\PotentialAttackException\SignatureThresholdExpception
+     * The metadata file will be stored as '$role.json'.
+     *
+     * @param string $role
+     *   The role name. This may be 'targets' or a delegated role.
      */
-    protected function fetchAndVerifyTargetMetadata(string $role): TargetsMetadata {
+    private function fetchAndVerifyTargetsMetadata(string $role): void
+    {
         $newSnapshotData = SnapshotMetadata::createFromJson($this->durableStorage['snapshot.json']);
         $newSnapshotData->setIsTrusted(true);
         $targetsVersion = $newSnapshotData->getFileMetaInfo("$role.json")['version'];
@@ -670,6 +671,5 @@ class Updater
         $newTargetsData->setIsTrusted(true);
         // TUF-SPEC-v1.0.9 Section 5.4.4
         $this->durableStorage["$role.json"] = $newTargetsContent;
-        return $newTargetsData;
     }
 }


### PR DESCRIPTION
In https://github.com/php-tuf/php-tuf/pull/141 will repeat downloading other delegated target metadata files. This will be the same logic as `targets.json`.  This refactors it into method so we can reuse it.