### PR TITLE
Create Role class

### DIFF
--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -341,13 +341,13 @@ class Updater
     {
         $signatures = $metaData->getSignatures();
 
-        $roleInfo = $this->roleDB->getRoleInfo($metaData->getRole());
-        $needVerified = $roleInfo['threshold'];
+        $role = $this->roleDB->getRole($metaData->getRole());
+        $needVerified = $role->getThreshold();
         $haveVerified = 0;
 
         $canonicalBytes = JsonNormalizer::asNormalizedJson($metaData->getSigned());
         foreach ($signatures as $signature) {
-            if ($this->isKeyIdAcceptableForRole($signature['keyid'], $metaData->getRole())) {
+            if ($role->isKeyIdAcceptable($signature['keyid'])) {
                 $haveVerified += (int) $this->verifySingleSignature($canonicalBytes, $signature);
             }
             // @todo Determine if we should check all signatures and warn for
@@ -361,24 +361,6 @@ class Updater
         if ($haveVerified < $needVerified) {
             throw new SignatureThresholdExpception("Signature threshold not met on " . $metaData->getRole());
         }
-    }
-
-    /**
-     * Checks whether the given key is authorized for the role.
-     *
-     * @param string $keyId
-     *     The key ID to check.
-     * @param string $roleName
-     *     The role name to check (e.g. 'root', 'snapshot', etc.).
-     *
-     * @return boolean
-     *     TRUE if the key is authorized for the given role, or FALSE
-     *     otherwise.
-     */
-    protected function isKeyIdAcceptableForRole(string $keyId, string $roleName) : bool
-    {
-        $roleKeyIds = $this->roleDB->getRoleKeyIds($roleName);
-        return in_array($keyId, $roleKeyIds);
     }
 
     /**

--- a/src/Metadata/ConstraintsTrait.php
+++ b/src/Metadata/ConstraintsTrait.php
@@ -126,4 +126,18 @@ trait ConstraintsTrait
             ],
         ]);
     }
+
+    /**
+     * Gets the role constraints.
+     *
+     * @return \Symfony\Component\Validator\Constraints\Collection
+     *   The role constraints collection.
+     */
+    protected static function getRoleConstraints(): Collection
+    {
+        return new Collection(
+          self::getKeyidsConstraints() +
+          static::getThresholdConstraints()
+        );
+    }
 }

--- a/src/Metadata/ConstraintsTrait.php
+++ b/src/Metadata/ConstraintsTrait.php
@@ -9,12 +9,38 @@ use Symfony\Component\Validator\Constraints\Count;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Type;
+use Symfony\Component\Validator\Validation;
+use Tuf\Exception\MetadataException;
 
 /**
  * Trait with methods to provide common constraints.
  */
 trait ConstraintsTrait
 {
+
+    /**
+     * Validates the structure of the metadata.
+     *
+     * @param \ArrayObject $data
+     *   The data to validate.
+     *
+     * @return void
+     *
+     * @throws \Tuf\Exception\MetadataException
+     *    Thrown if validation fails.
+     */
+    protected static function validateWithConstraints(\ArrayObject $data, Collection $collection): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $collection);
+        if (count($violations)) {
+            $exceptionMessages = [];
+            foreach ($violations as $violation) {
+                $exceptionMessages[] = (string) $violation;
+            }
+            throw new MetadataException(implode(",  \n", $exceptionMessages));
+        }
+    }
 
     /**
      * Gets the common hash constraints.
@@ -136,8 +162,8 @@ trait ConstraintsTrait
     protected static function getRoleConstraints(): Collection
     {
         return new Collection(
-          self::getKeyidsConstraints() +
-          static::getThresholdConstraints()
+            self::getKeyidsConstraints() +
+            static::getThresholdConstraints()
         );
     }
 }

--- a/src/Metadata/ConstraintsTrait.php
+++ b/src/Metadata/ConstraintsTrait.php
@@ -23,16 +23,18 @@ trait ConstraintsTrait
      *
      * @param \ArrayObject $data
      *   The data to validate.
+     * @param \Symfony\Component\Validator\Constraints\Collection $constraints
+     *   Th constraints collection for validation.
      *
      * @return void
      *
      * @throws \Tuf\Exception\MetadataException
      *    Thrown if validation fails.
      */
-    protected static function validateWithConstraints(\ArrayObject $data, Collection $collection): void
+    protected static function validate(\ArrayObject $data, Collection $constraints): void
     {
         $validator = Validation::createValidator();
-        $violations = $validator->validate($data, $collection);
+        $violations = $validator->validate($data, $constraints);
         if (count($violations)) {
             $exceptionMessages = [];
             foreach ($violations as $violation) {
@@ -162,7 +164,7 @@ trait ConstraintsTrait
     protected static function getRoleConstraints(): Collection
     {
         return new Collection(
-            self::getKeyidsConstraints() +
+            static::getKeyidsConstraints() +
             static::getThresholdConstraints()
         );
     }

--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -90,33 +90,8 @@ abstract class MetadataBase
     public static function createFromJson(string $json)
     {
         $data = JsonNormalizer::decode($json);
-        static::validateMetaData($data);
+        static::validateWithConstraints($data, new Collection(static::getConstraints()));
         return new static($data, $json);
-    }
-
-    /**
-     * Validates the structure of the metadata.
-     *
-     * @param \ArrayObject $metadata
-     *   The data to validate.
-     *
-     * @return void
-     *
-     * @throws \Tuf\Exception\MetadataException
-     *    Thrown if validation fails.
-     */
-    protected static function validateMetaData(\ArrayObject $metadata): void
-    {
-        $validator = Validation::createValidator();
-        $collection = new Collection(static::getConstraints());
-        $violations = $validator->validate($metadata, $collection);
-        if (count($violations)) {
-            $exceptionMessages = [];
-            foreach ($violations as $violation) {
-                $exceptionMessages[] = (string) $violation;
-            }
-            throw new MetadataException(implode(",  \n", $exceptionMessages));
-        }
     }
 
     /**

--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -90,7 +90,7 @@ abstract class MetadataBase
     public static function createFromJson(string $json)
     {
         $data = JsonNormalizer::decode($json);
-        static::validateWithConstraints($data, new Collection(static::getConstraints()));
+        static::validate($data, new Collection(static::getConstraints()));
         return new static($data, $json);
     }
 

--- a/src/Metadata/RootMetadata.php
+++ b/src/Metadata/RootMetadata.php
@@ -31,13 +31,13 @@ class RootMetadata extends MetadataBase
                 static::getKeyConstraints(),
             ]),
         ]);
-
+        $roleConstraints = static::getRoleConstraints();
         $options['fields']['roles'] = new Collection([
-            'targets' => new Required(static::getRoleConstraints()),
-            'timestamp' => new Required(static::getRoleConstraints()),
-            'snapshot' => new Required(static::getRoleConstraints()),
-            'root' => new Required(static::getRoleConstraints()),
-            'mirror' => new Optional(static::getRoleConstraints()),
+            'targets' => new Required($roleConstraints),
+            'timestamp' => new Required($roleConstraints),
+            'snapshot' => new Required($roleConstraints),
+            'root' => new Required($roleConstraints),
+            'mirror' => new Optional($roleConstraints),
         ]);
         $options['fields']['consistent_snapshot'] = new Required([
             new Type('boolean'),

--- a/src/Metadata/RootMetadata.php
+++ b/src/Metadata/RootMetadata.php
@@ -8,6 +8,7 @@ use Symfony\Component\Validator\Constraints\Count;
 use Symfony\Component\Validator\Constraints\Optional;
 use Symfony\Component\Validator\Constraints\Required;
 use Symfony\Component\Validator\Constraints\Type;
+use Tuf\Role;
 
 class RootMetadata extends MetadataBase
 {
@@ -53,17 +54,17 @@ class RootMetadata extends MetadataBase
      * @param boolean $allowUntrustedAccess
      *   Whether this method should access even if the metadata is not trusted.
      *
-     * @return \ArrayObject
-     *   An ArrayObject where the keys are role names and the values arrays with the
-     *   following keys:
-     *   - keyids (string[]): The key ids.
-     *   - threshold (int): Determines how many how may keys are need from
-     *     this role for signing.
+     * @return \Tuf\Role[]
+     *   The roles.
      */
-    public function getRoles(bool $allowUntrustedAccess = false):\ArrayObject
+    public function getRoles(bool $allowUntrustedAccess = false): array
     {
         $this->ensureIsTrusted($allowUntrustedAccess);
-        return $this->getSigned()['roles'];
+        $roles = [];
+        foreach ($this->getSigned()['roles'] as $roleName => $roleInfo) {
+            $roles[$roleName] = Role::createFromMetadata($roleInfo, $roleName);
+        }
+        return $roles;
     }
 
     /**

--- a/src/Metadata/RootMetadata.php
+++ b/src/Metadata/RootMetadata.php
@@ -31,16 +31,13 @@ class RootMetadata extends MetadataBase
                 static::getKeyConstraints(),
             ]),
         ]);
-        $roleConstraints = new Collection(
-            self::getKeyidsConstraints() +
-            static::getThresholdConstraints()
-        );
+
         $options['fields']['roles'] = new Collection([
-            'targets' => new Required($roleConstraints),
-            'timestamp' => new Required($roleConstraints),
-            'snapshot' => new Required($roleConstraints),
-            'root' => new Required($roleConstraints),
-            'mirror' => new Optional($roleConstraints),
+            'targets' => new Required(static::getRoleConstraints()),
+            'timestamp' => new Required(static::getRoleConstraints()),
+            'snapshot' => new Required(static::getRoleConstraints()),
+            'root' => new Required(static::getRoleConstraints()),
+            'mirror' => new Optional(static::getRoleConstraints()),
         ]);
         $options['fields']['consistent_snapshot'] = new Required([
             new Type('boolean'),

--- a/src/Role.php
+++ b/src/Role.php
@@ -67,32 +67,12 @@ class Role
      */
     public static function createFromMetadata(\ArrayObject $roleInfo, string $name): self
     {
-        self::validateRoleInfo($roleInfo);
+        self::validateWithConstraints($roleInfo, static::getRoleConstraints());
         return new static(
             $name,
             $roleInfo['threshold'],
             $roleInfo['keyids']
         );
-    }
-
-    /**
-     * Validates the role info.
-     *
-     * @param \ArrayObject $roleInfo
-     *
-     * @throws \Tuf\Exception\MetadataException
-     */
-    private static function validateRoleInfo(\ArrayObject $roleInfo)
-    {
-        $validator = Validation::createValidator();
-        $violations = $validator->validate($roleInfo, static::getRoleConstraints());
-        if (count($violations)) {
-            $exceptionMessages = [];
-            foreach ($violations as $violation) {
-                $exceptionMessages[] = (string) $violation;
-            }
-            throw new MetadataException(implode(",  \n", $exceptionMessages));
-        }
     }
 
     /**

--- a/src/Role.php
+++ b/src/Role.php
@@ -2,9 +2,6 @@
 
 namespace Tuf;
 
-use Symfony\Component\Validator\Constraints\Collection;
-use Symfony\Component\Validator\Validation;
-use Tuf\Exception\MetadataException;
 use Tuf\Metadata\ConstraintsTrait;
 
 /**
@@ -35,7 +32,6 @@ class Role
      */
     protected $keyIds;
 
-
     /**
      * Role constructor.
      *
@@ -63,11 +59,11 @@ class Role
      *
      * @return static
      *
-     * @see @see https://github.com/theupdateframework/specification/blob/v1.0.9/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.9/tuf-spec.md#4-document-formats
      */
     public static function createFromMetadata(\ArrayObject $roleInfo, string $name): self
     {
-        self::validateWithConstraints($roleInfo, static::getRoleConstraints());
+        self::validate($roleInfo, static::getRoleConstraints());
         return new static(
             $name,
             $roleInfo['threshold'],

--- a/src/Role.php
+++ b/src/Role.php
@@ -100,8 +100,8 @@ class Role
      *     TRUE if the key is authorized for the given role, or FALSE
      *     otherwise.
      */
-    public function isKeyIdAcceptable($keyId): bool
+    public function isKeyIdAcceptable(string $keyId): bool
     {
-        return in_array($keyId, $this->keyIds);
+        return in_array($keyId, $this->keyIds, true);
     }
 }

--- a/src/Role.php
+++ b/src/Role.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tuf;
+
+/**
+ * Class that represents a TUF role.
+ */
+class Role
+{
+
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var int
+     */
+    protected $threshold;
+
+    /**
+     * @var array
+     */
+    protected $keyIds;
+
+
+    /**
+     * Role constructor.
+     */
+    private function __construct(string $name, int $threshold, array $keyIds)
+    {
+        $this->name = $name;
+        $this->threshold = $threshold;
+        $this->keyIds = $keyIds;
+    }
+
+    /**
+     * Creates a role object from TUF metadata.
+     *
+     * @param \ArrayObject $roleInfo
+     *   The role information from TUF metadata.
+     *
+     * @return static
+     */
+    public static function createFromMetadata(\ArrayObject $roleInfo, string $name): self
+    {
+        return new static(
+            $name,
+            $roleInfo['threshold'],
+            $roleInfo['keyids']
+        );
+    }
+
+    /**
+     * Gets the role name.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Gets the threshold required.
+     *
+     * @return int
+     *   The threshold number of signatures required for the role.
+     */
+    public function getThreshold(): int
+    {
+        return $this->threshold;
+    }
+
+
+    /**
+     * Checks whether the given key is authorized for the role.
+     *
+     * @param string $keyId
+     *     The key ID to check.
+     *
+     * @return boolean
+     *     TRUE if the key is authorized for the given role, or FALSE
+     *     otherwise.
+     */
+    public function isKeyIdAcceptable($keyId): bool
+    {
+        return in_array($keyId, $this->keyIds);
+    }
+}

--- a/src/Role.php
+++ b/src/Role.php
@@ -9,16 +9,22 @@ class Role
 {
 
     /**
+     * The role name.
+     *
      * @var string
      */
     protected $name;
 
     /**
+     * The role threshold.
+     *
      * @var int
      */
     protected $threshold;
 
     /**
+     * The key IDs.
+     *
      * @var array
      */
     protected $keyIds;
@@ -26,6 +32,13 @@ class Role
 
     /**
      * Role constructor.
+     *
+     * @param string $name
+     *   The name of the role.
+     * @param int $threshold
+     *   The role threshold.
+     * @param array $keyIds
+     *   The key IDs.
      */
     private function __construct(string $name, int $threshold, array $keyIds)
     {
@@ -39,8 +52,12 @@ class Role
      *
      * @param \ArrayObject $roleInfo
      *   The role information from TUF metadata.
+     * @param string $name
+     *   The name of the role.
      *
      * @return static
+     *
+     * @see @see https://github.com/theupdateframework/specification/blob/v1.0.9/tuf-spec.md#4-document-formats
      */
     public static function createFromMetadata(\ArrayObject $roleInfo, string $name): self
     {

--- a/tests/Unit/RoleTest.php
+++ b/tests/Unit/RoleTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tuf\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Tuf\Role;
+
+/**
+ * @coversDefaultClass \Tuf\Role
+ */
+class RoleTest extends TestCase
+{
+
+    /**
+     * @covers ::createFromMetadata
+     * @covers ::getName
+     * @covers ::getThreshold
+     */
+    public function testCreateFromMetadata(): void
+    {
+        $role = Role::createFromMetadata(
+            new \ArrayObject([
+                'threshold' => 1000,
+                'keyids' => [
+                    'good_key_1',
+                    'good_key_2',
+                ]
+            ]),
+            'my_role'
+        );
+        self::assertSame(1000, $role->getThreshold());
+        self::assertSame('my_role', $role->getName());
+    }
+
+    /**
+     * @covers ::isKeyIdAcceptable
+     *
+     * @param string $keyId
+     * @param bool $expected
+     *
+     * @dataProvider providerIsKeyIdAcceptable
+     */
+    public function testIsKeyIdAcceptable(string $keyId, bool $expected): void
+    {
+        $role = Role::createFromMetadata(
+            new \ArrayObject([
+                'threshold' => 1000,
+                'keyids' => [
+                    'good_key_1',
+                    'good_key_2',
+                ]
+            ]),
+            'myrole'
+        );
+        self::assertSame($expected, $role->isKeyIdAcceptable($keyId));
+    }
+
+    /**
+     * Data provider for testIsKeyIdAcceptable().
+     *
+     * @return array[]
+     */
+    public function providerIsKeyIdAcceptable(): array
+    {
+        return [
+            ['good_key_1', true],
+            ['good_key_2', true],
+            ['bad_key', false],
+        ];
+    }
+}

--- a/tests/Unit/RoleTest.php
+++ b/tests/Unit/RoleTest.php
@@ -3,6 +3,7 @@
 namespace Tuf\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use Tuf\Exception\MetadataException;
 use Tuf\Role;
 
 /**
@@ -30,6 +31,39 @@ class RoleTest extends TestCase
         );
         self::assertSame(1000, $role->getThreshold());
         self::assertSame('my_role', $role->getName());
+    }
+
+    /**
+     * @covers ::createFromMetadata
+     *
+     * @param $data
+     *   Invalid data.
+     *
+     * @dataProvider providerInvalidMetadata
+     */
+    public function testInvalidMetadata($data): void
+    {
+        $this->expectException(MetadataException::class);
+        Role::createFromMetadata(
+            new \ArrayObject($data),
+            'my_role'
+        );
+    }
+
+    /**
+     * Data provider for testInvalidMetadata().
+     *
+     * @return array[]
+     */
+    public function providerInvalidMetadata(): array
+    {
+        return [
+            'nothing' => [[]],
+            'no keyids' => [['threshold' => 1]],
+            'no threshold' => [['keyids' => ['good_key']]],
+            'invalid threshold' => [['threshold' => '1', 'keyids' => ['good_key']]],
+            'invalid keyids' => [['threshold' => 1, 'keyids' => 'good_key_1,good_key_2']],
+        ];
     }
 
     /**

--- a/tests/Unit/RoleTest.php
+++ b/tests/Unit/RoleTest.php
@@ -63,6 +63,7 @@ class RoleTest extends TestCase
             'no threshold' => [['keyids' => ['good_key']]],
             'invalid threshold' => [['threshold' => '1', 'keyids' => ['good_key']]],
             'invalid keyids' => [['threshold' => 1, 'keyids' => 'good_key_1,good_key_2']],
+            'extra field' => [['threshold' => 1, 'keyids' => ['good_key'], 'extra_field' => 1]],
         ];
     }
 


### PR DESCRIPTION
The roleDB is kind of messy. Not only keeps track of roles but also has to know the structure of those roles.

Also `Updater::isKeyIdAcceptableForRole()` could be moved to a new Role class.

In https://github.com/php-tuf/php-tuf/pull/141 we will need more info from special type of role. We could create `DelegatedRole extends Role` with `DelegatedRole::matchTargetPath($target)`