### PR TITLE
remove phpcodesniffer-composer-installer dependency and unused use statements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,7 @@
     "require-dev": {
         "phpunit/phpunit": "^8.5.8|^9",
         "symfony/phpunit-bridge": "^5",
-        "php-tuf/phpcodesniffer-standard": "dev-main",
-        "dealerdirect/phpcodesniffer-composer-installer": "dev-master"
+        "php-tuf/phpcodesniffer-standard": "dev-main"
     },
     "license": "MIT",
     "minimum-stability": "dev",

--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -12,8 +12,6 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Component\Validator\Constraints\Required;
 use Symfony\Component\Validator\Constraints\Type;
-use Symfony\Component\Validator\Validation;
-use Tuf\Exception\MetadataException;
 use Tuf\JsonNormalizer;
 
 /**

--- a/tests/Metadata/RootMetadataTest.php
+++ b/tests/Metadata/RootMetadataTest.php
@@ -5,7 +5,6 @@ namespace Tuf\Tests\Metadata;
 use Tuf\Exception\MetadataException;
 use Tuf\Metadata\MetadataBase;
 use Tuf\Metadata\RootMetadata;
-use Tuf\Role;
 
 /**
  * @coversDefaultClass \Tuf\Metadata\RootMetadata

--- a/tests/Unit/Client/UpdaterTest.php
+++ b/tests/Unit/Client/UpdaterTest.php
@@ -7,8 +7,6 @@ use Tuf\Client\RepoFileFetcherInterface;
 use Tuf\Client\Updater;
 use Tuf\Metadata\MetadataBase;
 
-use Tuf\Tests\TestHelpers\DurableStorage\MemoryStorageLoaderTrait;
-
 /**
  * @covers \Tuf\Client\Updater
  */

--- a/tests/Unit/GuzzleFileFetcherTest.php
+++ b/tests/Unit/GuzzleFileFetcherTest.php
@@ -9,11 +9,9 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7\Response;
-use PhpParser\Node\Arg;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Tuf\Client\GuzzleFileFetcher;
-use Tuf\Exception\DownloadSizeException;
 use Tuf\Exception\RepoFileNotFound;
 
 /**


### PR DESCRIPTION
We not longer need a direct dependency on `phpcodesniffer-composer-installer` now that we have `php-tuf/phpcodesniffer-standard`. This was causing a requirements error.

Also removing unused use statements because of new `php-tuf/phpcodesniffer-standard` rule.