### PR TITLE
Issue #56 fix use of keyid_hash_algorithms in key data

### DIFF
--- a/src/Exception/InvalidKeyException.php
+++ b/src/Exception/InvalidKeyException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tuf\Exception;
+
+/**
+ * Indicates an invalid key or unsupported key type.
+ */
+class InvalidKeyException extends TufException
+{
+}

--- a/src/KeyDB.php
+++ b/src/KeyDB.php
@@ -4,6 +4,7 @@
 namespace Tuf;
 
 use DeepCopy\DeepCopy;
+use Tuf\Exception\InvalidKeyException;
 use Tuf\Exception\NotFoundException;
 use Tuf\Metadata\RootMetadata;
 
@@ -39,8 +40,8 @@ class KeyDB
      * @return \Tuf\KeyDB
      *     The constructed key database object.
      *
-     * @throws \Exception
-     *   Thrown if an unsupported key type exists in the metadata.
+     * @throws \Tuf\Exception\InvalidKeyException
+     *   Thrown if an unsupported or invalid key exists in the metadata.
      *
      * @see https://github.com/theupdateframework/specification/blob/v1.0.9/tuf-spec.md#4-document-formats
      */
@@ -48,8 +49,8 @@ class KeyDB
     {
         $db = new self();
 
-        foreach ($rootMetadata->getKeys($allowUntrustedAccess) as $keyMeta) {
-            $db->addKey($keyMeta);
+        foreach ($rootMetadata->getKeys($allowUntrustedAccess) as $keyId => $keyMeta) {
+            $db->addKey($keyId, $keyMeta);
         }
 
         return $db;
@@ -73,14 +74,17 @@ class KeyDB
     }
 
     /**
-     * Computes the hashed keys IDs for the given key metadata.
+     * Computes the key ID for the given key metadata.
+     *
+     * Per specification section 4.2, the KEYID is a hexdigest of the SHA-256
+     * hash of the canonical form of the key.
      *
      * @param \ArrayAccess $keyMeta
      *     An ArrayAccess object of key metadata. See self::addKey() and the TUF
      *     specification for the array structure.
      *
      * @return string
-     *     The hashed key ID for the key metadata using sha256.
+     *     The key ID in hex format for the key metadata hashed using sha256.
      *
      * @see https://github.com/theupdateframework/specification/blob/v1.0.9/tuf-spec.md#4-document-formats
      *
@@ -90,10 +94,12 @@ class KeyDB
     {
         // @see https://github.com/secure-systems-lab/securesystemslib/blob/master/securesystemslib/keys.py
         // The keyid_hash_algorithms array value is based on the TUF settings,
-        // it's not expected to be part of the key data. The fact that it is
+        // it's not expected to be part of the key metadata. The fact that it is
         // currently included is a quirk of the TUF python code that may be
-        // fixed in future versions. For simplicity, hard-code it using the
-        // normal TUF settings.
+        // fixed in future versions. Calculate using the normal TUF settings
+        // since this is how it's calculated in the securesystemslib code and
+        // any value for keyid_hash_algorithms in the key data in root.json is
+        // ignored.
         $keyCanonicalStruct = [
             'keytype' => $keyMeta['keytype'],
             'scheme' => $keyMeta['scheme'],
@@ -116,29 +122,31 @@ class KeyDB
     /**
      * Adds key metadata to the key database while avoiding duplicates.
      *
+     * @param string $keyId
+     *   The key ID given as the object key in root.json or another keys list.
      * @param \ArrayAccess $keyMeta
      *     An associative array of key metadata, including:
      *     - keytype: The public key signature system, e.g. 'ed25519'.
      *     - scheme: The corresponding signature scheme, e.g. 'ed25519'.
      *     - keyval: An associative array containing the public key value.
-     *     - keyid_hash_algorithms: @todo This differs from the spec. See
-     *       linked issue.
      *
      * @return void
      *
-     * @see https://github.com/theupdateframework/specification/blob/v1.0.9/tuf-spec.md#4-document-formats
-     *
-     * @todo https://github.com/php-tuf/php-tuf/issues/56
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.16/tuf-spec.md#4-document-formats
      */
-    private function addKey(\ArrayAccess $keyMeta): void
+    private function addKey(string $keyId, \ArrayAccess $keyMeta): void
     {
         if (! in_array($keyMeta['keytype'], self::getSupportedKeyTypes(), true)) {
             // @todo Convert this to a log line as per Python.
             // https://github.com/php-tuf/php-tuf/issues/160
-            throw new \Exception("Root metadata file contains an unsupported key type: \"${keyMeta['keytype']}\"");
+            throw new InvalidKeyException("Root metadata file contains an unsupported key type: \"${keyMeta['keytype']}\"");
         }
-        // One key ID for each $keyMeta['keyid_hash_algorithms'].
         $computedKeyId = self::computeKeyId($keyMeta);
+        // Per TUF specification 4.3, Clients MUST calculate each KEYID to
+        // verify this is correct for the associated key.
+        if ($keyId !== $computedKeyId) {
+            throw new InvalidKeyException('The calculated KEYID does not match the value provided.');
+        }
         $this->keys[$computedKeyId] = $keyMeta;
     }
 

--- a/tests/KeyDBTest.php
+++ b/tests/KeyDBTest.php
@@ -34,17 +34,13 @@ class KeyDBTest extends TestCase
         // Get the first key for comparison.
         $key = $rootMetadata->getKeys()->getIterator()->current();
         $jsonEncodedKey = json_encode($key);
-        // Create the 2 hashed versions of the key id which can be used by getKey().
+        // Re-create the the key id which can be used by getKey().
         $keyNormalized = JsonNormalizer::asNormalizedJson($key);
         $keyId256 = hash('sha256', $keyNormalized);
-        $keyId512 = hash('sha512', $keyNormalized);
         self::assertSame($jsonEncodedKey, json_encode($keyDb->getKey($keyId256)));
-        self::assertSame($jsonEncodedKey, json_encode($keyDb->getKey($keyId512)));
 
         // Ensure that changing a value in the key does not affect the internal state of the KeyDB object.
         $key256['keyval']['new_key'] = 'new_value';
-        $key512['keyval']['new_key'] = 'new_value';
         self::assertSame($jsonEncodedKey, json_encode($keyDb->getKey($keyId256)));
-        self::assertSame($jsonEncodedKey, json_encode($keyDb->getKey($keyId512)));
     }
 }


### PR DESCRIPTION
The current implementation of generating multiple key IDs and allowing them to be used is not in line with the spec and opens a security hole, per discussion yesterday with @tedbow 