### PR TITLE
Make Updater::verify() and ::checkLength() protected

### DIFF
--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -522,7 +522,7 @@ class Updater
      * @throws \Tuf\Exception\DownloadSizeException
      *   If the stream's length exceeds $maxBytes in size.
      */
-    private function checkLength(StreamInterface $data, int $maxBytes, string $fileName): void
+    protected function checkLength(StreamInterface $data, int $maxBytes, string $fileName): void
     {
         $error = new DownloadSizeException("$fileName exceeded $maxBytes bytes");
         $size = $data->getSize();
@@ -559,7 +559,7 @@ class Updater
      * @throws \Tuf\Exception\PotentialAttackException\InvalidHashException
      *   If the data stream does not match the known hash(es) for the target.
      */
-    public function verify(string $target, StreamInterface $data): void
+    protected function verify(string $target, StreamInterface $data): void
     {
         $this->refresh();
 


### PR DESCRIPTION
As per discussion with @tedbow, @effulgentsia, and @xjm, we want to hide the implementation of `Updater::verify()` and `Updater::checkLength()` so that consumers of PHP-TUF that need to use their own download mechanism -- like the Composer integration plugin, for example -- can do so by extending `Updater`, but still take advantage of TUF's verification mechanisms.