### PR TITLE
Ensure that keyid_hash_algorithm is equal to exact expected value

### DIFF
--- a/src/Metadata/ConstraintsTrait.php
+++ b/src/Metadata/ConstraintsTrait.php
@@ -128,6 +128,12 @@ trait ConstraintsTrait
     protected static function getKeyConstraints(): Collection
     {
         return new Collection([
+            // This field is not part of the TUF specification and is being
+            // removed from the Python TUF reference implementation in
+            // https://github.com/theupdateframework/tuf/issues/848.
+            // If it is provided though we only support the default value which
+            // is passed on from a setting in the Python `securesystemslib`
+            // library.
             'keyid_hash_algorithms' => [
                 new Optional(),
                 new EqualTo(['value' =>["sha256", "sha512"]]),

--- a/src/Metadata/ConstraintsTrait.php
+++ b/src/Metadata/ConstraintsTrait.php
@@ -6,6 +6,7 @@ namespace Tuf\Metadata;
 use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\Count;
+use Symfony\Component\Validator\Constraints\EqualTo;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Type;
@@ -127,13 +128,7 @@ trait ConstraintsTrait
     {
         return new Collection([
             'keyid_hash_algorithms' => [
-                new Count(['min' => 1]),
-                new Type(['type' => 'array']),
-              // The keys for 'hashes is not know but they all must be strings.
-                new All([
-                    new Type(['type' => 'string']),
-                    new NotBlank(),
-                ]),
+                new EqualTo(["sha256", "sha512"])
             ],
             'keytype' => [
                 new Type(['type' => 'string']),

--- a/src/Metadata/ConstraintsTrait.php
+++ b/src/Metadata/ConstraintsTrait.php
@@ -130,7 +130,7 @@ trait ConstraintsTrait
         return new Collection([
             'keyid_hash_algorithms' => [
                 new Optional(),
-                new EqualTo(["sha256", "sha512"]),
+                new EqualTo(['value' =>["sha256", "sha512"]]),
             ],
             'keytype' => [
                 new Type(['type' => 'string']),

--- a/src/Metadata/ConstraintsTrait.php
+++ b/src/Metadata/ConstraintsTrait.php
@@ -9,6 +9,7 @@ use Symfony\Component\Validator\Constraints\Count;
 use Symfony\Component\Validator\Constraints\EqualTo;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Optional;
 use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Component\Validator\Validation;
 use Tuf\Exception\MetadataException;
@@ -128,7 +129,8 @@ trait ConstraintsTrait
     {
         return new Collection([
             'keyid_hash_algorithms' => [
-                new EqualTo(["sha256", "sha512"])
+                new Optional(),
+                new EqualTo(["sha256", "sha512"]),
             ],
             'keytype' => [
                 new Type(['type' => 'string']),

--- a/src/Metadata/ConstraintsTrait.php
+++ b/src/Metadata/ConstraintsTrait.php
@@ -136,7 +136,7 @@ trait ConstraintsTrait
             // library.
             'keyid_hash_algorithms' => [
                 new Optional(),
-                new EqualTo(['value' =>["sha256", "sha512"]]),
+                new EqualTo(['value' => ["sha256", "sha512"]]),
             ],
             'keytype' => [
                 new Type(['type' => 'string']),

--- a/tests/Metadata/RootMetadataTest.php
+++ b/tests/Metadata/RootMetadataTest.php
@@ -198,7 +198,8 @@ class RootMetadataTest extends MetadataBaseTest
      *
      * @see \Tuf\Metadata\ConstraintsTrait::getKeyConstraints()
      */
-    public function testKeyidHashAlgorithms() {
+    public function testKeyidHashAlgorithms()
+    {
         $json = $this->localRepo[$this->validJson];
         $data = json_decode($json, true);
         $keyId = array_keys($data['signed']['keys'])[0];

--- a/tests/Metadata/RootMetadataTest.php
+++ b/tests/Metadata/RootMetadataTest.php
@@ -58,7 +58,6 @@ class RootMetadataTest extends MetadataBaseTest
     {
         $data = parent::providerValidField();
         $firstKey = $this->getFixtureNestedArrayFirstKey($this->validJson, ['signed', 'keys']);
-        $data[] = ["signed:keys:$firstKey:keyid_hash_algorithms", 'array'];
         $data[] = ["signed:keys:$firstKey:keytype", 'string'];
         $data[] = ["signed:keys:$firstKey:keyval", 'array'];
         $data[] = ["signed:keys:$firstKey:keyval:public", 'string'];
@@ -192,5 +191,22 @@ class RootMetadataTest extends MetadataBaseTest
             }
             self::assertFalse($roles[$expectRoleName]->isKeyIdAcceptable('nobodys_key'));
         }
+    }
+
+    /**
+     * Test that keyid_hash_algorithms must equal the exact value.
+     *
+     * @see \Tuf\Metadata\ConstraintsTrait::getKeyConstraints()
+     */
+    public function testKeyidHashAlgorithms() {
+        $json = $this->localRepo[$this->validJson];
+        $data = json_decode($json, true);
+        $keyId = array_keys($data['signed']['keys'])[0];
+        $data['signed']['keys'][$keyId]['keyid_hash_algorithms'][1] = 'sha513';
+        self::expectException(MetadataException::class);
+        $expectedMessage = preg_quote("Object(ArrayObject)[signed][keys][$keyId][keyid_hash_algorithms]:", '/');
+        $expectedMessage .= '.* This value should be equal to array';
+        self::expectExceptionMessageMatches("/$expectedMessage/s");
+        static::callCreateFromJson(json_encode($data));
     }
 }

--- a/tests/Metadata/RootMetadataTest.php
+++ b/tests/Metadata/RootMetadataTest.php
@@ -202,7 +202,7 @@ class RootMetadataTest extends MetadataBaseTest
     {
         $json = $this->localRepo[$this->validJson];
         $data = json_decode($json, true);
-        $keyId = array_keys($data['signed']['keys'])[0];
+        $keyId = key($data['signed']['keys']);
         $data['signed']['keys'][$keyId]['keyid_hash_algorithms'][1] = 'sha513';
         self::expectException(MetadataException::class);
         $expectedMessage = preg_quote("Object(ArrayObject)[signed][keys][$keyId][keyid_hash_algorithms]:", '/');

--- a/tests/Metadata/TargetsMetadataTest.php
+++ b/tests/Metadata/TargetsMetadataTest.php
@@ -175,7 +175,7 @@ class TargetsMetadataTest extends MetadataBaseTest
     {
         $json = $this->localRepo[$this->validJson];
         $data = json_decode($json, true);
-        $keyId = array_keys($data['signed']['delegations']['keys'])[0];
+        $keyId = key($data['signed']['delegations']['keys']);
         $data['signed']['delegations']['keys'][$keyId]['keyid_hash_algorithms'][1] = 'sha513';
         self::expectException(MetadataException::class);
         $expectedMessage = preg_quote("Object(ArrayObject)[signed][delegations][keys][$keyId][keyid_hash_algorithms]:", '/');

--- a/tests/Metadata/TargetsMetadataTest.php
+++ b/tests/Metadata/TargetsMetadataTest.php
@@ -171,7 +171,8 @@ class TargetsMetadataTest extends MetadataBaseTest
      *
      * @see \Tuf\Metadata\ConstraintsTrait::getKeyConstraints()
      */
-    public function testKeyidHashAlgorithms() {
+    public function testKeyidHashAlgorithms()
+    {
         $json = $this->localRepo[$this->validJson];
         $data = json_decode($json, true);
         $keyId = array_keys($data['signed']['delegations']['keys'])[0];

--- a/tests/Metadata/TargetsMetadataTest.php
+++ b/tests/Metadata/TargetsMetadataTest.php
@@ -2,6 +2,7 @@
 
 namespace Tuf\Tests\Metadata;
 
+use Tuf\Exception\MetadataException;
 use Tuf\Exception\NotFoundException;
 use Tuf\Metadata\MetadataBase;
 use Tuf\Metadata\TargetsMetadata;
@@ -163,5 +164,22 @@ class TargetsMetadataTest extends MetadataBaseTest
         // Confirm that if a role name is specified this will be returned.
         $metadata = static::callCreateFromJson($this->localRepo[$this->validJson], 'other_role');
         $this->assertSame('other_role', $metadata->getRole());
+    }
+
+    /**
+     * Test that keyid_hash_algorithms must equal the exact value.
+     *
+     * @see \Tuf\Metadata\ConstraintsTrait::getKeyConstraints()
+     */
+    public function testKeyidHashAlgorithms() {
+        $json = $this->localRepo[$this->validJson];
+        $data = json_decode($json, true);
+        $keyId = array_keys($data['signed']['delegations']['keys'])[0];
+        $data['signed']['delegations']['keys'][$keyId]['keyid_hash_algorithms'][1] = 'sha513';
+        self::expectException(MetadataException::class);
+        $expectedMessage = preg_quote("Object(ArrayObject)[signed][delegations][keys][$keyId][keyid_hash_algorithms]:", '/');
+        $expectedMessage .= '.* This value should be equal to array';
+        self::expectExceptionMessageMatches("/$expectedMessage/s");
+        static::callCreateFromJson(json_encode($data));
     }
 }


### PR DESCRIPTION
In #174  we realized `keyid_hash_algorithms` should not vary and we don't actually need it from metadata to compute the key. Currently in `\Tuf\Metadata\ConstraintsTrait::getKeyConstraints()` we allow any non-empty array of strings. This changes to only except the exact value `["sha256", "sha512"]`