### PR TITLE
In addition to metadata files load all targets in \Tuf\Tests\Client\TestRepo::__construct()

### DIFF
--- a/tests/Client/TestRepo.php
+++ b/tests/Client/TestRepo.php
@@ -35,8 +35,13 @@ class TestRepo implements RepoFileFetcherInterface
     {
         // Store all the repo files locally so they can be easily altered.
         // @see self::setRepoFileNestedValue()
-        $repoFiles = glob(static::getFixturesRealPath($fixturesSet, '/tufrepo/metadata') . '/*.json');
-        foreach ($repoFiles as $repoFile) {
+        $metadataFiles = glob(static::getFixturesRealPath($fixturesSet, '/tufrepo/metadata') . '/*.json');
+        $targetFiles = glob(static::getFixturesRealPath($fixturesSet, '/tufrepo/targets') . '/*');
+        foreach (array_merge($metadataFiles, $targetFiles) as $repoFile) {
+            $baseName = basename($repoFile);
+            if (isset($this->repoFilesContents[basename($repoFile)])) {
+                throw new \UnexpectedValueException("For testing fixtures target files should not use metadata file names");
+            }
             $this->repoFilesContents[basename($repoFile)] = file_get_contents($repoFile);
         }
     }

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -146,7 +146,6 @@ class UpdaterTest extends TestCase
 
         $testFilePath = static::getFixturesRealPath($fixturesSet, 'tufrepo/targets/testtarget.txt', false);
         $testFileContents = file_get_contents($testFilePath);
-        $this->testRepo->repoFilesContents['testtarget.txt'] = $testFileContents;
         $this->assertSame($testFileContents, $updater->download('testtarget.txt')->wait()->getContents());
 
         // If the file fetcher returns a file stream, the updater should NOT try
@@ -156,7 +155,6 @@ class UpdaterTest extends TestCase
         $stream->getContents()->shouldNotBeCalled();
         $stream->rewind()->shouldNotBeCalled();
         $stream->getSize()->willReturn(strlen($testFileContents));
-        $this->testRepo->repoFilesContents['testtarget.txt'] = new FulfilledPromise($stream->reveal());
         $updater->download('testtarget.txt')->wait();
 
         // If the target isn't known, we should get a rejected promise.
@@ -250,7 +248,6 @@ class UpdaterTest extends TestCase
         foreach ($expectedClientVersionsAfterDownloads as $delegatedFile => $expectedClientVersions) {
             $testFilePath = static::getFixturesRealPath($fixturesSet, "tufrepo/targets/$delegatedFile", false);
             $testFileContents = file_get_contents($testFilePath);
-            $this->testRepo->repoFilesContents[$delegatedFile] = $testFileContents;
             $this->assertSame($testFileContents, $updater->download($delegatedFile)->wait()->getContents());
             $this->assertClientRepoVersions($expectedClientVersions);
         }
@@ -270,8 +267,6 @@ class UpdaterTest extends TestCase
         $this->testRepo = new TestRepo($fixturesSet);
         $updater = $this->getSystemInTest();
         $testFilePath = static::getFixturesRealPath($fixturesSet, "tufrepo/targets/$fileName", false);
-        $testFileContents = file_get_contents($testFilePath);
-        $this->testRepo->repoFilesContents[$fileName] = $testFileContents;
         self::expectException(NotFoundException::class);
         self::expectExceptionMessage("Target not found: $fileName");
         $updater->download($fileName)->wait();


### PR DESCRIPTION
In some of our tests we load the target files like this:

`$this->testRepo->repoFilesContents['testtarget.txt'] = $testFileContents;`

We shouldn't need to do that on a per test method basis if we are testing a successful download of the target.