### PR TITLE
Add a fixture with a terminating role that still delegates

### DIFF
--- a/generate_fixtures.py
+++ b/generate_fixtures.py
@@ -228,16 +228,24 @@ class TUFTestFixtureNestedDelegatedErrors(TUFTestFixtureNestedDelegated):
         level_1_delegation = self.repository.targets._delegated_roles.get('unclaimed')
 
         # Delegate from level_1_delegation to level_1 target-signing key
-        (public_level_2_error_key, private_level_2_error_key) = self.write_and_import_keypair(
+        (public_key, private_key) = self.write_and_import_keypair(
             'targets_level_2_error')
 
         # Add a delegation that does not match the pattern of level_1 delegation
         # Nothing in this delegation should be found.
         level_1_delegation.delegate(
-            'level_2_error', [public_level_2_error_key], ['level_2_*.txt'])
+            'level_2_error', [public_key], ['level_2_*.txt'])
         self.write_and_add_target('level_2_unfindable.txt', 'level_2_error')
         level_1_delegation('level_2').load_signing_key(
-            private_level_2_error_key)
+            private_key)
+
+
+        # Add a delegation that matches the path pattern 'test_nested2_*.txt'
+        level_1_delegation.delegate(
+            'level_2_terminating', [public_key], ['level_1_2_terminating_*.txt'], terminating=True)
+        self.write_and_add_target('level_1_2_terminating_findable.txt', 'level_2_terminating')
+
+
 
         self.write_and_publish_repository(export_client=False)
 

--- a/generate_fixtures.py
+++ b/generate_fixtures.py
@@ -202,6 +202,13 @@ class TUFTestFixtureNestedDelegated(TUFTestFixtureDelegated):
         level_1_delegation('level_2').load_signing_key(
             private_level_2_key)
 
+        # Add a terminating delegation.
+        level_1_delegation.delegate(
+            'level_2_terminating', [public_level_2_key], ['level_1_2_terminating_*.txt'], terminating=True)
+        self.write_and_add_target('level_1_2_terminating_findable.txt', 'level_2_terminating')
+        level_1_delegation('level_2_terminating').load_signing_key(
+            private_level_2_key)
+
         level_2_delegation = level_1_delegation._delegated_roles.get('level_2')
 
         # Delegate from level_1 to nested2_delegation delegation target-signing key
@@ -239,11 +246,12 @@ class TUFTestFixtureNestedDelegatedErrors(TUFTestFixtureNestedDelegated):
         level_1_delegation('level_2').load_signing_key(
             private_key)
 
-
-        # Add a delegation that matches the path pattern 'test_nested2_*.txt'
-        level_1_delegation.delegate(
-            'level_2_terminating', [public_key], ['level_1_2_terminating_*.txt'], terminating=True)
-        self.write_and_add_target('level_1_2_terminating_findable.txt', 'level_2_terminating')
+        level_2_terminating_delegation = self.repository.targets._delegated_roles.get('level_2_terminating')
+        level_2_terminating_delegation.delegate(
+            'level_3_below_terminated', [public_key], ['level_1_2_terminating_unfindable_*.txt'])
+        self.write_and_add_target('level_1_2_terminating_unfindable_target.txt', 'level_3_below_terminated')
+        level_2_terminating_delegation('level_3_below_terminated').load_signing_key(
+            private_key)
 
 
 

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -235,6 +235,17 @@ class UpdaterTest extends TestCase
                 'targets' => 6,
                 'unclaimed' => 2,
                 'level_2' => 1,
+                'level_2_terminating' => null,
+                'level_3' => null,
+            ],
+            'level_1_2_terminating_findable.txt' => [
+                'root' => 6,
+                'timestamp' => 6,
+                'snapshot' => 6,
+                'targets' => 6,
+                'unclaimed' => 2,
+                'level_2' => 1,
+                'level_2_terminating' => 1,
                 'level_3' => null,
             ],
             'level_1_2_3_target.txt' => [
@@ -244,6 +255,7 @@ class UpdaterTest extends TestCase
                 'targets' => 6,
                 'unclaimed' => 2,
                 'level_2' => 1,
+                'level_2_terminating' => 1,
                 'level_3' => 1,
             ],
         ];
@@ -304,6 +316,11 @@ class UpdaterTest extends TestCase
             // 'paths' property is incompatible with the its parent delegation's
             // 'paths' property.
             'delegated path does not match parent' => ['level_2_unfindable.txt'],
+            // ''level_1_2_terminating_unfindable_target.txt' is add via role
+            // 'level_3_below_terminated' which is delegated from role 'level_2_terminating'.
+            // Because 'level_2_terminating' is terminating role no roles it delegates to
+            // should be evaluated.
+            'parent delegation is terminating' => ['level_1_2_terminating_unfindable_target.txt']
         ];
     }
 


### PR DESCRIPTION
If a role has `terminating: true` any role it delegates to should not be evaluated. The python library does allow this though