### PR TITLE
Mark path_hash_prefixes as unsupported

### DIFF
--- a/generate_fixtures.py
+++ b/generate_fixtures.py
@@ -186,6 +186,20 @@ class TUFTestFixtureDelegated(TUFTestFixtureSimple):
             ['root', 'snapshot', 'targets', 'timestamp'])
         self.write_and_publish_repository()
 
+class TUFTestFixtureUnsupportedDelegation(TUFTestFixtureSimple):
+    def __init__(self):
+        super().__init__()
+
+        # Delegate to an unclaimed target-signing key
+        (public_unclaimed_key, private_unclaimed_key) = self.write_and_import_keypair(
+            'targets_delegated')
+        self.repository.targets.delegate(
+            'unsupported_target', [public_unclaimed_key], ['unsupported_*.txt'], path_hash_prefixes= ['ab34df13'])
+        self.write_and_add_target('unsupported_target.txt', 'unsupported_target')
+        self.repository.targets('unsupported_target').load_signing_key(
+            private_unclaimed_key)
+        self.write_and_publish_repository(export_client=False)
+
 class TUFTestFixtureNestedDelegated(TUFTestFixtureDelegated):
     def __init__(self):
         super().__init__()
@@ -300,6 +314,7 @@ def generate_fixtures():
     TUFTestFixtureSimple()
     TUFTestFixtureDelegated()
     TUFTestFixtureNestedDelegated()
+    TUFTestFixtureUnsupportedDelegation()
     TUFTestFixtureNestedDelegatedErrors()
     TUFTestFixtureAttackRollback()
     TUFTestFixtureThresholdTwo()

--- a/generate_fixtures.py
+++ b/generate_fixtures.py
@@ -187,6 +187,7 @@ class TUFTestFixtureDelegated(TUFTestFixtureSimple):
         self.write_and_publish_repository()
 
 class TUFTestFixtureUnsupportedDelegation(TUFTestFixtureSimple):
+    # Sets up a repo using `path_hash_prefixes` which is currently not supported.
     def __init__(self):
         super().__init__()
 

--- a/src/Metadata/TargetsMetadata.php
+++ b/src/Metadata/TargetsMetadata.php
@@ -4,6 +4,7 @@ namespace Tuf\Metadata;
 
 use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Constraints\Collection;
+use Tuf\Constraints\Collection as TufCollection;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Optional;
@@ -57,22 +58,27 @@ class TargetsMetadata extends MetadataBase
                 ]),
                 'roles' => new All([
                     new Type('\ArrayObject'),
-                    new Collection([
-                        'name' => [
-                            new NotBlank(),
-                            new Type(['type' => 'string']),
-                        ],
-                        'paths' => [
-                            new Type(['type' => 'array']),
-                            new All([
-                                new Type(['type' => 'string']),
+                    new TufCollection([
+                        'fields' => [
+                            'name' => [
                                 new NotBlank(),
-                            ]),
-                        ],
-                        'terminating' => [
-                            new Type(['type' => 'boolean']),
-                        ],
-                    ] + static::getKeyidsConstraints() + static::getThresholdConstraints()),
+                                new Type(['type' => 'string']),
+                            ],
+                            'paths' => [
+                                new Type(['type' => 'array']),
+                                new All([
+                                    new Type(['type' => 'string']),
+                                    new NotBlank(),
+                                ]),
+                            ],
+                            'terminating' => [
+                                new Type(['type' => 'boolean']),
+                            ],
+                        ] + static::getKeyidsConstraints() + static::getThresholdConstraints(),
+                        // @todo Support 'path_hash_prefixes' in
+                        //    https://github.com/php-tuf/php-tuf/issues/191
+                        'unsupportedFields' => ['path_hash_prefixes'],
+                    ]),
                 ]),
             ]),
         ]);

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -61,7 +61,7 @@ class UpdaterTest extends TestCase
                 'timestamp' => 2,
                 'snapshot' => 2,
                 'unsupported_target' => null,
-             // We cannot assert the starting versions of 'targets' because it has
+              // We cannot assert the starting versions of 'targets' because it has
               // an unsupported field and would throw an exception when validating.
             ],
             'TUFTestFixtureSimple' => [

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -61,7 +61,7 @@ class UpdaterTest extends TestCase
                 'timestamp' => 2,
                 'snapshot' => 2,
                 'unsupported_target' => null,
-            // We cannot assert the starting versions of 'targets' because it has
+             // We cannot assert the starting versions of 'targets' because it has
               // an unsupported field and would throw an exception when validating.
             ],
             'TUFTestFixtureSimple' => [

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -792,27 +792,6 @@ class UpdaterTest extends TestCase
     }
 
     /**
-     * Data provider for testAttackRepoException().
-     * @return array[]
-     *   The test cases.
-     */
-    public function providerUnsupportedRepo(): array
-    {
-        return [
-            [
-                'TUFTestFixtureUnsupportedDelegation',
-                new MetadataException('Remote timestamp metadata version "$2" is less than previously seen timestamp version "$3"'),
-                [
-                    'root' => 3,
-                    'timestamp' => 3,
-                    'snapshot' => 3,
-                    'targets' => 3,
-                ],
-            ],
-        ];
-    }
-
-    /**
      * Tests that exceptions are thrown when a repo is in a rollback attack state.
      *
      * @param string $fixturesSet

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -771,7 +771,7 @@ class UpdaterTest extends TestCase
         } catch (MetadataException $exception) {
             $expectedMessage = preg_quote("Object(ArrayObject)[signed][delegations][roles][0][path_hash_prefixes]:", '/');
             $expectedMessage .= ".*This field is not supported.";
-            self::assertMatchesRegularExpression("/$expectedMessage/s", $exception->getMessage());
+            self::assertSame(1, preg_match("/$expectedMessage/s", $exception->getMessage()));
             // Assert that the root, timestamp and snapshot metadata files were updated
             // and that the unsupported_target metadata file was not downloaded.
             $expectedUpdatedVersion = [

--- a/tests/Metadata/SnapshotMetadataTest.php
+++ b/tests/Metadata/SnapshotMetadataTest.php
@@ -2,13 +2,13 @@
 
 namespace Tuf\Tests\Metadata;
 
-use Tuf\Exception\MetadataException;
 use Tuf\Metadata\MetadataBase;
 use Tuf\Metadata\SnapshotMetadata;
 
 class SnapshotMetadataTest extends MetadataBaseTest
 {
     use UntrustedExceptionTrait;
+    use UnsupportedFieldsTestTrait;
 
     /**
      * {@inheritdoc}
@@ -52,30 +52,6 @@ class SnapshotMetadataTest extends MetadataBaseTest
     }
 
     /**
-     * Tests that unsupported fields throw an exception.
-     *
-     * @param array $unsupportedField
-     *   The array of nested keys for the unsupported field.
-     * @param mixed $fieldValue
-     *   The field value to set.
-     *
-     * @dataProvider providerUnsupportedFields
-     *
-     * @return void
-     */
-    public function testUnsupportedFields(array $unsupportedField, $fieldValue): void
-    {
-        $metadata = json_decode($this->localRepo[$this->validJson], true);
-        $this->nestedChange($unsupportedField, $metadata, $fieldValue);
-        $fieldName = array_pop($unsupportedField);
-        $expectedMessage = preg_quote("Object(ArrayObject)[signed][meta][targets.json][$fieldName]", '/');
-        $expectedMessage .= ".*This field is not supported.";
-        $this->expectException(MetadataException::class);
-        $this->expectExceptionMessageMatches("/$expectedMessage/s");
-        static::callCreateFromJson(json_encode($metadata));
-    }
-
-    /**
      * Data provider for testUnsupportedFields().
      *
      * @return array[]
@@ -83,10 +59,16 @@ class SnapshotMetadataTest extends MetadataBaseTest
      */
     public function providerUnsupportedFields(): array
     {
-        return [
+        $cases = [
             'length' => [['signed', 'meta', 'targets.json', 'length'], 1],
             'hashes' => [['signed', 'meta', 'targets.json', 'hashes'], []],
         ];
+        foreach ($cases as $fieldName => &$case) {
+            $expectedMessage = preg_quote("Object(ArrayObject)[signed][meta][targets.json][$fieldName]", '/');
+            $expectedMessage .= ".*This field is not supported.";
+            $case[] = $expectedMessage;
+        }
+        return $cases;
     }
 
     /**

--- a/tests/Metadata/TargetsMetadataTest.php
+++ b/tests/Metadata/TargetsMetadataTest.php
@@ -12,6 +12,7 @@ use Tuf\Metadata\TargetsMetadata;
  */
 class TargetsMetadataTest extends MetadataBaseTest
 {
+    use UnsupportedFieldsTestTrait;
 
     /**
      * {@inheritdoc}
@@ -203,5 +204,24 @@ class TargetsMetadataTest extends MetadataBaseTest
         $expectedMessage .= '.* This value should be equal to array';
         self::expectExceptionMessageMatches("/$expectedMessage/s");
         static::callCreateFromJson(json_encode($data));
+    }
+
+    /**
+     * Data provider for testUnsupportedFields().
+     *
+     * @return array[]
+     *  The test cases.
+     */
+    public function providerUnsupportedFields(): array
+    {
+        $expectedMessage = preg_quote("Object(ArrayObject)[signed][delegations][roles][0][path_hash_prefixes]", '/');
+        $expectedMessage .= ".*This field is not supported.";
+        $cases['path_hash_prefixes'] = [
+            ['signed', 'delegations', 'roles', 0, 'path_hash_prefixes'],
+            [],
+            $expectedMessage,
+
+        ];
+        return $cases;
     }
 }

--- a/tests/Metadata/UnsupportedFieldsTestTrait.php
+++ b/tests/Metadata/UnsupportedFieldsTestTrait.php
@@ -28,9 +28,8 @@ trait UnsupportedFieldsTestTrait
     {
         $metadata = json_decode($this->localRepo[$this->validJson], true);
         $this->nestedChange($unsupportedField, $metadata, $fieldValue);
-        $fieldName = array_pop($unsupportedField);
-        $this->expectException(MetadataException::class);
-        $this->expectExceptionMessageMatches("/$expectedMessage/s");
+        self::expectException(MetadataException::class);
+        self::expectExceptionMessageMatches("/$expectedMessage/s");
         static::callCreateFromJson(json_encode($metadata));
     }
 

--- a/tests/Metadata/UnsupportedFieldsTestTrait.php
+++ b/tests/Metadata/UnsupportedFieldsTestTrait.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tuf\Tests\Metadata;
+
+use Tuf\Exception\MetadataException;
+
+/**
+ * Test method for testing unsupported fields.
+ */
+trait UnsupportedFieldsTestTrait
+{
+
+    /**
+     * Tests that unsupported fields throw an exception.
+     *
+     * @param array $unsupportedField
+     *   The array of nested keys for the unsupported field.
+     * @param mixed $fieldValue
+     *   The field value to set.
+     * @param string $expectedMessage
+     *   The expected regex exception message.
+     *
+     * @dataProvider providerUnsupportedFields
+     *
+     * @return void
+     */
+    public function testUnsupportedFields(array $unsupportedField, $fieldValue, string $expectedMessage): void
+    {
+        $metadata = json_decode($this->localRepo[$this->validJson], true);
+        $this->nestedChange($unsupportedField, $metadata, $fieldValue);
+        $fieldName = array_pop($unsupportedField);
+        $this->expectException(MetadataException::class);
+        $this->expectExceptionMessageMatches("/$expectedMessage/s");
+        static::callCreateFromJson(json_encode($metadata));
+    }
+
+    /**
+     * Data provider for testUnsupportedFields().
+     *
+     * @return array[]
+     *  The test cases.
+     */
+    abstract public function providerUnsupportedFields(): array;
+}

--- a/tests/Metadata/UnsupportedFieldsTestTrait.php
+++ b/tests/Metadata/UnsupportedFieldsTestTrait.php
@@ -9,7 +9,6 @@ use Tuf\Exception\MetadataException;
  */
 trait UnsupportedFieldsTestTrait
 {
-
     /**
      * Tests that unsupported fields throw an exception.
      *


### PR DESCRIPTION
We have #191 to support `path_hash_prefixes` but until then lets throw a validation if it is set