### PR TITLE
Update TUF spec to 1.0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It should currently only be used for testing, development and feedback.
 PHP-TUF is a PHP implementation of [The Update Framework
 (TUF)](https://theupdateframework.io/) to provide signing and verification for
 secure PHP application updates. [Read the TUF
-specification](https://github.com/theupdateframework/specification/blob/v1.0.12/tuf-spec.md)
+specification](https://github.com/theupdateframework/specification/blob/v1.0.13/tuf-spec.md)
 for more information on how TUF is intended to work and the security it
 provides.
 
@@ -120,5 +120,5 @@ dependency information](DEPENDENCIES.md).
   * [Code Documentation: Main Index](https://github.com/theupdateframework/tuf/blob/develop/tuf/README.md)
   * [CLI](https://github.com/theupdateframework/tuf/blob/develop/docs/CLI.md)
   * [Python API Readme](https://github.com/theupdateframework/tuf/blob/develop/tuf/client/README.md)
-* [TUF Specification v1.0.12](https://github.com/theupdateframework/specification/blob/v1.0.12/tuf-spec.md)
+* [TUF Specification v1.0.13](https://github.com/theupdateframework/specification/blob/v1.0.13/tuf-spec.md)
 * [PIP + TUF Integration](https://www.python.org/dev/peps/pep-0458/)

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -88,7 +88,7 @@ class Updater
      *
      *   @return \DateTimeImmutable
      */
-    protected $metadataExpiration;
+    private $metadataExpiration;
 
     /**
      * Updater constructor.
@@ -491,7 +491,7 @@ class Updater
      * @throws \Tuf\Exception\FormatException
      *    Thrown if time format is not valid.
      */
-    protected function getMetadataExpirationTime(): \DateTimeImmutable
+    private function getMetadataExpirationTime(): \DateTimeImmutable
     {
         if (empty($this->metadataExpiration)) {
             throw new \LogicException("::setMetadataExpiration must be called before ::getMetadataExpirationTime");
@@ -764,14 +764,25 @@ class Updater
      *
      * @throws \Tuf\Exception\FormatException
      */
-    protected function setMetadataExpiration()
+    private function setMetadataExpiration()
     {
         if ($this->isRefreshed) {
             throw new \LogicException('::setMetadataExpiration() cannot be called after refresh has been called()');
         } elseif ($this->metadataExpiration) {
             throw new \LogicException('::setMetadataExpiration() should only be called once during ::refresh()');
         }
+        $this->metadataExpiration = $this->createExpirationDate();
+    }
+
+    /**
+     * Creates the expiration date after which metadata will be consider expired.
+     *
+     * @return \DateTimeImmutable
+     *   The expiration date.
+     */
+    protected function createExpirationDate(): \DateTimeImmutable
+    {
         $fakeNow = '2020-01-01T00:00:00Z';
-        $this->metadataExpiration = static::metadataTimestampToDateTime($fakeNow);
+        return static::metadataTimestampToDateTime($fakeNow);
     }
 }

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -336,18 +336,18 @@ class Updater
      *
      * @param \Tuf\Metadata\MetadataBase $metadata
      *     The metadata for the timestamp role.
-     * @param \DateTimeInterface $now
-     *     The current date and time at runtime.
+     * @param \DateTimeInterface $updaterMetadataExpirationTime
+     *     The time after which metadata should be considered expired.
      *
      * @return void
      *
      * @throws FreezeAttackException
      *     Thrown if a potential freeze attack is detected.
      */
-    protected static function checkFreezeAttack(MetadataBase $metadata, \DateTimeInterface $now): void
+    protected static function checkFreezeAttack(MetadataBase $metadata, \DateTimeInterface $updaterMetadataExpirationTime): void
     {
         $metadataExpiration = static::metadataTimestampToDatetime($metadata->getExpires());
-        if ($metadataExpiration < $now) {
+        if ($metadataExpiration < $updaterMetadataExpirationTime) {
             $format = "Remote %s metadata expired on %s";
             throw new FreezeAttackException(sprintf($format, $metadata->getRole(), $metadataExpiration->format('c')));
         }

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -740,7 +740,7 @@ class Updater
     }
 
     /**
-     * Creates the expiration date after which metadata will be consider expired.
+     * Creates the expiration date after which metadata will be considered expired.
      *
      * @return \DateTimeImmutable
      *   The expiration date.

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -748,6 +748,8 @@ class Updater
     protected function createExpirationDate(): \DateTimeImmutable
     {
         $fakeNow = '2020-01-01T00:00:00Z';
-        return static::metadataTimestampToDateTime($fakeNow);
+        // Allow metadata that expires five minutes after ::refresh() starts.
+        $expirationAdditionInterval = \DateInterval::createFromDateString("5 minutes");
+        return static::metadataTimestampToDateTime($fakeNow)->add($expirationAdditionInterval);
     }
 }

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -86,7 +86,7 @@ class Updater
     /**
      * The time after which metadata should be considered expired.
      *
-     *   @return \DateTimeImmutable
+     * @var \DateTimeImmutable
      */
     private $metadataExpiration;
 

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -88,7 +88,7 @@ class Updater
      *
      *   @return \DateTimeImmutable
      */
-    private $metadataExpiration;
+    protected $metadataExpiration;
 
     /**
      * Updater constructor.
@@ -491,7 +491,7 @@ class Updater
      * @throws \Tuf\Exception\FormatException
      *    Thrown if time format is not valid.
      */
-    private function getMetadataExpirationTime(): \DateTimeImmutable
+    protected function getMetadataExpirationTime(): \DateTimeImmutable
     {
         if (empty($this->metadataExpiration)) {
             throw new \LogicException("::setMetadataExpiration must be called before ::getMetadataExpirationTime");

--- a/src/Key.php
+++ b/src/Key.php
@@ -61,7 +61,7 @@ final class Key
      *
      * @return static
      *
-     * @see https://github.com/theupdateframework/specification/blob/v1.0.12/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.13/tuf-spec.md#4-document-formats
      */
     public static function createFromMetadata(\ArrayObject $keyInfo): self
     {
@@ -104,7 +104,7 @@ final class Key
      * @return string
      *     The key ID in hex format for the key metadata hashed using sha256.
      *
-     * @see https://github.com/theupdateframework/specification/blob/v1.0.12/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.13/tuf-spec.md#4-document-formats
      *
      * @todo https://github.com/php-tuf/php-tuf/issues/56
      */

--- a/src/KeyDB.php
+++ b/src/KeyDB.php
@@ -42,7 +42,7 @@ class KeyDB
      * @throws \Tuf\Exception\InvalidKeyException
      *   Thrown if an unsupported or invalid key exists in the metadata.
      *
-     * @see https://github.com/theupdateframework/specification/blob/v1.0.12/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.13/tuf-spec.md#4-document-formats
      */
     public static function createFromRootMetadata(RootMetadata $rootMetadata, bool $allowUntrustedAccess = false): KeyDB
     {
@@ -90,7 +90,7 @@ class KeyDB
      *
      * @return void
      *
-     * @see https://github.com/theupdateframework/specification/blob/v1.0.12/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.13/tuf-spec.md#4-document-formats
      */
     public function addKey(string $keyId, Key $key): void
     {
@@ -119,7 +119,7 @@ class KeyDB
      * @throws \Tuf\Exception\NotFoundException
      *     Thrown if the key ID is not found in the keydb database.
      *
-     * @see https://github.com/theupdateframework/specification/blob/v1.0.12/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.13/tuf-spec.md#4-document-formats
      */
     public function getKey(string $keyId): Key
     {

--- a/src/Role.php
+++ b/src/Role.php
@@ -59,7 +59,7 @@ class Role
      *
      * @return static
      *
-     * @see https://github.com/theupdateframework/specification/blob/v1.0.12/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.13/tuf-spec.md#4-document-formats
      */
     public static function createFromMetadata(\ArrayObject $roleInfo, string $name): Role
     {

--- a/src/RoleDB.php
+++ b/src/RoleDB.php
@@ -34,7 +34,7 @@ class RoleDB
      * @throws \Exception
      *     Thrown if a threshold value in the metadata is not valid.
      *
-     * @see https://github.com/theupdateframework/specification/blob/v1.0.12/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.13/tuf-spec.md#4-document-formats
      */
     public static function createFromRootMetadata(RootMetadata $rootMetadata, bool $allowUntrustedAccess = false): RoleDB
     {
@@ -101,7 +101,7 @@ class RoleDB
      * @throws \Tuf\Exception\NotFoundException
      *     Thrown if the role does not exist.
      *
-     * @see https://github.com/theupdateframework/specification/blob/v1.0.12/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.13/tuf-spec.md#4-document-formats
      */
     public function getRole(string $roleName): Role
     {

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -548,8 +548,8 @@ class UpdaterTest extends TestCase
             // will result in a MetadataException indicating that the contents hash does not match
             // the hashes specified in the timestamp.json. This is because timestamp.json in the test
             // fixtures contains the optional 'hashes' metadata for the snapshot.json files, and this
-            // is checked before the file signatures and the file version number.The order of checking
-            // is specified in TUF-SPEC-v1.0.12 Section 5.3.
+            // is checked before the file signatures and the file version number. The order of checking
+            // is specified in TUF-SPEC-v1.0.13 Section 5.5.
             [
                 '5.snapshot.json',
                 ['signed', 'newkey'],


### PR DESCRIPTION
Updates to spec version 1.0.13, according to the differences in `https://github.com/theupdateframework/specification/compare/v1.0.12...v1.0.13`.

The only functional change here was the introduction of a "now+T" time guard to defend against freeze attacks. I discussed this with @tedbow and we decided that the library's default functionality should be unchanged, but that consumers (like the Composer plugin) should be able to provide an adjusted expiration time if they want to, since the spec says that should be left up to the application using TUF.

Beyond that, there was a re-numbering of the spec sections, and that was a little tricky, so I'd ideally like two sign-offs here before that gets merged.