### PR TITLE
Create SignatureVerifier class to encapsulate signature verification logic

### DIFF
--- a/src/Client/SignatureVerifier.php
+++ b/src/Client/SignatureVerifier.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Tuf\Client;
-
 
 use Tuf\Exception\PotentialAttackException\SignatureThresholdExpception;
 use Tuf\JsonNormalizer;
@@ -13,40 +11,26 @@ use Tuf\Metadata\RootMetadata;
 use Tuf\Role;
 use Tuf\RoleDB;
 
+/**
+ * A class that verifies metadata signatures.
+ */
 class SignatureVerifier
 {
 
     /**
      * @var \Tuf\RoleDB
      */
-    protected $roleDb;
+    private $roleDb;
 
     /**
      * @var \Tuf\KeyDB
      */
-    protected $keyDb;
-
-    /**
-     * @return \Tuf\RoleDB
-     */
-    public function getRoleDb(): RoleDB
-    {
-        return $this->roleDb;
-    }
-
-    /**
-     * @return \Tuf\KeyDB
-     */
-    public function getKeyDb(): KeyDB
-    {
-        return $this->keyDb;
-    }
-
+    private $keyDb;
 
     /**
      * SignatureVerifier constructor.
      */
-    public function __construct(RoleDB $roleDb, KeyDB $keyDb)
+    private function __construct(RoleDB $roleDb, KeyDB $keyDb)
     {
         $this->roleDb = $roleDb;
         $this->keyDb = $keyDb;
@@ -55,8 +39,8 @@ class SignatureVerifier
     public static function createFromRootMetadata(RootMetadata $rootMetadata, bool $allowUntrustedAccess = false): SignatureVerifier
     {
         return new static(
-          RoleDB::createFromRootMetadata($rootMetadata, $allowUntrustedAccess),
-          KeyDB::createFromRootMetadata($rootMetadata, $allowUntrustedAccess)
+            RoleDB::createFromRootMetadata($rootMetadata, $allowUntrustedAccess),
+            KeyDB::createFromRootMetadata($rootMetadata, $allowUntrustedAccess)
         );
     }
 
@@ -127,14 +111,30 @@ class SignatureVerifier
         return \sodium_crypto_sign_verify_detached($sigBytes, $bytes, $pubkeyBytes);
     }
 
-    public function addRole(Role $role) {
+    /**
+     * Adds a role to the signature verifier.
+     *
+     * @param \Tuf\Role $role
+     *
+     * @throws \Exception
+     */
+    public function addRole(Role $role):void
+    {
         if (!$this->roleDb->roleExists($role->getName())) {
             $this->roleDb->addRole($role);
         }
     }
 
-    public function addKey(string $keyId, Key $key) {
+    /**
+     * Adds a key to the signature verifier.
+     *
+     * @param string $keyId
+     * @param \Tuf\Key $key
+     *
+     * @throws \Tuf\Exception\InvalidKeyException
+     */
+    public function addKey(string $keyId, Key $key):void
+    {
         $this->keyDb->addKey($keyId, $key);
     }
-
 }

--- a/src/Client/SignatureVerifier.php
+++ b/src/Client/SignatureVerifier.php
@@ -1,0 +1,140 @@
+<?php
+
+
+namespace Tuf\Client;
+
+
+use Tuf\Exception\PotentialAttackException\SignatureThresholdExpception;
+use Tuf\JsonNormalizer;
+use Tuf\Key;
+use Tuf\KeyDB;
+use Tuf\Metadata\MetadataBase;
+use Tuf\Metadata\RootMetadata;
+use Tuf\Role;
+use Tuf\RoleDB;
+
+class SignatureVerifier
+{
+
+    /**
+     * @var \Tuf\RoleDB
+     */
+    protected $roleDb;
+
+    /**
+     * @var \Tuf\KeyDB
+     */
+    protected $keyDb;
+
+    /**
+     * @return \Tuf\RoleDB
+     */
+    public function getRoleDb(): RoleDB
+    {
+        return $this->roleDb;
+    }
+
+    /**
+     * @return \Tuf\KeyDB
+     */
+    public function getKeyDb(): KeyDB
+    {
+        return $this->keyDb;
+    }
+
+
+    /**
+     * SignatureVerifier constructor.
+     */
+    public function __construct(RoleDB $roleDb, KeyDB $keyDb)
+    {
+        $this->roleDb = $roleDb;
+        $this->keyDb = $keyDb;
+    }
+
+    public static function createFromRootMetadata(RootMetadata $rootMetadata, bool $allowUntrustedAccess = false): SignatureVerifier
+    {
+        return new static(
+          RoleDB::createFromRootMetadata($rootMetadata, $allowUntrustedAccess),
+          KeyDB::createFromRootMetadata($rootMetadata, $allowUntrustedAccess)
+        );
+    }
+
+    /**
+     * Checks signatures on a verifiable structure.
+     *
+     * @param \Tuf\Metadata\MetadataBase $metadata
+     *     The metadata to check signatures on.
+     *
+     * @return void
+     *
+     * @throws \Tuf\Exception\PotentialAttackException\SignatureThresholdExpception
+     *   Thrown if the signature threshold has not be reached.
+     */
+    public function checkSignatures(MetadataBase $metadata): void
+    {
+        $signatures = $metadata->getSignatures();
+
+        $role = $this->roleDb->getRole($metadata->getRole());
+        $needVerified = $role->getThreshold();
+        $verifiedKeySignatures = [];
+
+        $canonicalBytes = JsonNormalizer::asNormalizedJson($metadata->getSigned());
+        foreach ($signatures as $signature) {
+            // Don't allow the same key to be counted twice.
+            if ($role->isKeyIdAcceptable($signature['keyid']) && $this->verifySingleSignature($canonicalBytes, $signature)) {
+                $verifiedKeySignatures[$signature['keyid']] = true;
+            }
+            // @todo Determine if we should check all signatures and warn for
+            //     bad signatures even if this method returns TRUE because the
+            //     threshold has been met.
+            //     https://github.com/php-tuf/php-tuf/issues/172
+            if (count($verifiedKeySignatures) >= $needVerified) {
+                break;
+            }
+        }
+
+        if (count($verifiedKeySignatures) < $needVerified) {
+            throw new SignatureThresholdExpception("Signature threshold not met on " . $metadata->getRole());
+        }
+    }
+
+    /**
+     * @param string $bytes
+     *     The canonical JSON string of the 'signed' section of the given file.
+     * @param \ArrayAccess $signatureMeta
+     *     The ArrayAccess object of metadata for the signature. Each signature
+     *     metadata contains two elements:
+     *     - keyid: The identifier of the key signing the role data.
+     *     - sig: The hex-encoded signature of the canonical form of the
+     *       metadata for the role.
+     *
+     * @return boolean
+     *     TRUE if the signature is valid for the.
+     */
+    protected function verifySingleSignature(string $bytes, \ArrayAccess $signatureMeta): bool
+    {
+        // Get the pubkey from the key database.
+        $pubkey = $this->keyDb->getKey($signatureMeta['keyid'])->getPublic();
+
+        // Encode the pubkey and signature, and check that the signature is
+        // valid for the given data and pubkey.
+        $pubkeyBytes = hex2bin($pubkey);
+        $sigBytes = hex2bin($signatureMeta['sig']);
+        // @todo Check that the key type in $signatureMeta is ed25519; return
+        //     false if not.
+        //     https://github.com/php-tuf/php-tuf/issues/168
+        return \sodium_crypto_sign_verify_detached($sigBytes, $bytes, $pubkeyBytes);
+    }
+
+    public function addRole(Role $role) {
+        if (!$this->roleDb->roleExists($role->getName())) {
+            $this->roleDb->addRole($role);
+        }
+    }
+
+    public function addKey(string $keyId, Key $key) {
+        $this->keyDb->addKey($keyId, $key);
+    }
+
+}

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -14,7 +14,6 @@ use Tuf\Exception\PotentialAttackException\DenialOfServiceAttackException;
 use Tuf\Exception\PotentialAttackException\FreezeAttackException;
 use Tuf\Exception\PotentialAttackException\InvalidHashException;
 use Tuf\Exception\PotentialAttackException\RollbackAttackException;
-use Tuf\JsonNormalizer;
 use Tuf\Metadata\MetadataBase;
 use Tuf\Metadata\RootMetadata;
 use Tuf\Metadata\SnapshotMetadata;


### PR DESCRIPTION
I am closing out #89 because I don't think it is good idea. The TUF spec doesn't always check the signatures of metadata files first but it does first verify the files(which checking signatures is 1 part of) before use.

We have since added `\Tuf\Metadata\MetadataBase::ensureIsTrusted()` to ensure we never **unintentionally** access the metadata before we verify it. This allows us to access certain data, such as version number as part of the verification before we check signatures.

So the only thing I really liked about #89 was refactoring out the `SignatureVerifier` class. 

This creates that class. It allows the updater to not have to directly care about the role or key dbs.

I am ok with not doing this but it does make the `Updater` class, which is getting pretty big, smaller 