### PR TITLE
Update TUF spec to 1.0.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It should currently only be used for testing, development and feedback.
 PHP-TUF is a PHP implementation of [The Update Framework
 (TUF)](https://theupdateframework.io/) to provide signing and verification for
 secure PHP application updates. [Read the TUF
-specification](https://github.com/theupdateframework/specification/blob/v1.0.15/tuf-spec.md)
+specification](https://github.com/theupdateframework/specification/blob/v1.0.16/tuf-spec.md)
 for more information on how TUF is intended to work and the security it
 provides.
 
@@ -120,5 +120,5 @@ dependency information](DEPENDENCIES.md).
   * [Code Documentation: Main Index](https://github.com/theupdateframework/tuf/blob/develop/tuf/README.md)
   * [CLI](https://github.com/theupdateframework/tuf/blob/develop/docs/CLI.md)
   * [Python API Readme](https://github.com/theupdateframework/tuf/blob/develop/tuf/client/README.md)
-* [TUF Specification v1.0.15](https://github.com/theupdateframework/specification/blob/v1.0.15/tuf-spec.md)
+* [TUF Specification v1.0.16](https://github.com/theupdateframework/specification/blob/v1.0.16/tuf-spec.md)
 * [PIP + TUF Integration](https://www.python.org/dev/peps/pep-0458/)

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -172,46 +172,46 @@ class Updater
             return true;
         }
 
-        // *TUF-SPEC-v1.0.15 Section 5.0
-        $this->metadataExpiration = $this->createExpirationDate();
+        // *TUF-SPEC-v1.0.16 Section 5.0
+        $this->metadataExpiration = $this->getUpdateStartTime();
 
-        // *TUF-SPEC-v1.0.15 Section 5.1
+        // *TUF-SPEC-v1.0.16 Section 5.1
         $rootData = RootMetadata::createFromJson($this->durableStorage['root.json']);
         $rootData->setIsTrusted(true);
 
         $this->roleDB = RoleDB::createFromRootMetadata($rootData);
         $this->keyDB = KeyDB::createFromRootMetadata($rootData);
 
-        // *TUF-SPEC-v1.0.15 Section 5.2
+        // *TUF-SPEC-v1.0.16 Section 5.2
         $this->updateRoot($rootData);
 
-        // *TUF-SPEC-v1.0.15 Section 5.3
+        // *TUF-SPEC-v1.0.16 Section 5.3
         $newTimestampContents = $this->fetchFile('timestamp.json');
         $newTimestampData = TimestampMetadata::createFromJson($newTimestampContents);
-        // *TUF-SPEC-v1.0.15 Section 5.3.1
+        // *TUF-SPEC-v1.0.16 Section 5.3.1
         $this->checkSignatures($newTimestampData);
 
         // If the timestamp or snapshot keys were rotating then the timestamp file
         // will not exist.
         if (isset($this->durableStorage['timestamp.json'])) {
-            // *TUF-SPEC-v1.0.15 Section 5.3.2.1 and 5.3.2.2
+            // *TUF-SPEC-v1.0.16 Section 5.3.2.1 and 5.3.2.2
             $currentStateTimestampData = TimestampMetadata::createFromJson($this->durableStorage['timestamp.json']);
             static::checkRollbackAttack($currentStateTimestampData, $newTimestampData);
         }
 
-        // *TUF-SPEC-v1.0.15 Section 5.3.3
+        // *TUF-SPEC-v1.0.16 Section 5.3.3
         static::checkFreezeAttack($newTimestampData, $this->metadataExpiration);
-        // TUF-SPEC-v1.0.15 Section 5.3.4: Persist timestamp metadata
+        // TUF-SPEC-v1.0.16 Section 5.3.4: Persist timestamp metadata
         $this->durableStorage['timestamp.json'] = $newTimestampContents;
         $newTimestampData->setIsTrusted(true);
 
         $snapshotInfo = $newTimestampData->getFileMetaInfo('snapshot.json');
         $snapShotVersion = $snapshotInfo['version'];
 
-        // TUF-SPEC-v1.0.15 Section 5.4
+        // TUF-SPEC-v1.0.16 Section 5.4
         if ($rootData->supportsConsistentSnapshots()) {
             $newSnapshotContents = $this->fetchFile("$snapShotVersion.snapshot.json");
-            // TUF-SPEC-v1.0.15 Section 5.4.1
+            // TUF-SPEC-v1.0.16 Section 5.4.1
             $newSnapshotData = SnapshotMetadata::createFromJson($newSnapshotContents);
             $newTimestampData->verifyNewHashes($newSnapshotData);
         } else {
@@ -220,26 +220,26 @@ class Updater
             throw new \UnexpectedValueException("Currently only repos using consistent snapshots are supported.");
         }
 
-        // TUF-SPEC-v1.0.15 Section 5.4.2
+        // TUF-SPEC-v1.0.16 Section 5.4.2
         $this->checkSignatures($newSnapshotData);
 
-        // TUF-SPEC-v1.0.15 Section 5.4.3
+        // TUF-SPEC-v1.0.16 Section 5.4.3
         $newTimestampData->verifyNewVersion($newSnapshotData);
 
         if (isset($this->durableStorage['snapshot.json'])) {
             $currentSnapShotData = SnapshotMetadata::createFromJson($this->durableStorage['snapshot.json']);
-            // TUF-SPEC-v1.0.15 Section 5.4.4
+            // TUF-SPEC-v1.0.16 Section 5.4.4
             static::checkRollbackAttack($currentSnapShotData, $newSnapshotData);
         }
 
-        // TUF-SPEC-v1.0.15 Section 5.4.5
+        // TUF-SPEC-v1.0.16 Section 5.4.5
         static::checkFreezeAttack($newSnapshotData, $this->metadataExpiration);
 
-        // TUF-SPEC-v1.0.15 Section 5.4.6
+        // TUF-SPEC-v1.0.16 Section 5.4.6
         $this->durableStorage['snapshot.json'] = $newSnapshotContents;
         $newSnapshotData->setIsTrusted(true);
 
-        // TUF-SPEC-v1.0.15 Section 5.5
+        // TUF-SPEC-v1.0.16 Section 5.5
         if ($rootData->supportsConsistentSnapshots()) {
             $this->fetchAndVerifyTargetsMetadata('targets');
         } else {
@@ -319,7 +319,7 @@ class Updater
                         throw new RollbackAttackException($message);
                     }
                 } elseif ($type === 'snapshot' && static::getFileNameType($fileName) === 'targets') {
-                    // TUF-SPEC-v1.0.15 Section 5.4.4
+                    // TUF-SPEC-v1.0.16 Section 5.4.4
                     // Any targets metadata filename that was listed in the trusted snapshot metadata file, if any, MUST
                     // continue to be listed in the new snapshot metadata file.
                     throw new RollbackAttackException("Remote snapshot metadata file references '$fileName' but this is not present in the remote file");
@@ -442,7 +442,7 @@ class Updater
     {
         $rootsDownloaded = 0;
         $originalRootData = $rootData;
-        // *TUF-SPEC-v1.0.15 Section 5.2.2
+        // *TUF-SPEC-v1.0.16 Section 5.2.2
         $nextVersion = $rootData->getVersion() + 1;
         while ($nextRootContents = $this->repoFileFetcher->fetchMetadataIfExists("$nextVersion.root.json", static::MAXIMUM_DOWNLOAD_BYTES)) {
             $rootsDownloaded++;
@@ -450,30 +450,30 @@ class Updater
                 throw new DenialOfServiceAttackException("The maximum number root files have already been downloaded: " . static::MAX_ROOT_DOWNLOADS);
             }
             $nextRoot = RootMetadata::createFromJson($nextRootContents);
-            // *TUF-SPEC-v1.0.15 Section 5.2.3
+            // *TUF-SPEC-v1.0.16 Section 5.2.3
             $this->checkSignatures($nextRoot);
             // Update Role and Key databases to use the new root information.
             $this->roleDB = RoleDB::createFromRootMetadata($nextRoot, true);
             $this->keyDB = KeyDB::createFromRootMetadata($nextRoot, true);
             $this->checkSignatures($nextRoot);
-            // *TUF-SPEC-v1.0.15 Section 5.2.4
+            // *TUF-SPEC-v1.0.16 Section 5.2.4
             static::checkRollbackAttack($rootData, $nextRoot, $nextVersion);
             $nextRoot->setIsTrusted(true);
             $rootData = $nextRoot;
-            // *TUF-SPEC-v1.0.15 Section 5.2.5 - Needs no action.
+            // *TUF-SPEC-v1.0.16 Section 5.2.5 - Needs no action.
             // Note that the expiration of the new (intermediate) root metadata
             // file does not matter yet, because we will check for it in step
             // 1.8.
 
-            // *TUF-SPEC-v1.0.15 Section 5.2.6 and 5.2.7
+            // *TUF-SPEC-v1.0.16 Section 5.2.6 and 5.2.7
             $this->durableStorage['root.json'] = $nextRootContents;
             $nextVersion = $rootData->getVersion() + 1;
-            // *TUF-SPEC-v1.0.15 Section 5.2.8 Repeat the above steps.
+            // *TUF-SPEC-v1.0.16 Section 5.2.8 Repeat the above steps.
         }
-        // *TUF-SPEC-v1.0.15 Section 5.2.9
+        // *TUF-SPEC-v1.0.16 Section 5.2.9
         static::checkFreezeAttack($rootData, $this->metadataExpiration);
 
-        // *TUF-SPEC-v1.0.15 Section 5.2.10: Delete the trusted timestamp and snapshot files if either
+        // *TUF-SPEC-v1.0.16 Section 5.2.10: Delete the trusted timestamp and snapshot files if either
         // file has rooted keys.
         if ($rootsDownloaded &&
            (static::hasRotatedKeys($originalRootData, $rootData, 'timestamp')
@@ -681,7 +681,7 @@ class Updater
         foreach ($targetsMetadata->getDelegatedRoles() as $delegatedRole) {
             $delegatedRoleName = $delegatedRole->getName();
             if (in_array($delegatedRoleName, $searchedRoles, true)) {
-                // TUF-SPEC-v1.0.15 Section 5.5.6.1
+                // TUF-SPEC-v1.0.16 Section 5.5.6.1
                 // If this role has been visited before, then skip this role (so that cycles in the delegation graph are avoided).
                 continue;
             }
@@ -726,30 +726,28 @@ class Updater
         $targetsVersion = $newSnapshotData->getFileMetaInfo("$role.json")['version'];
         $newTargetsContent = $this->fetchFile("$targetsVersion.$role.json");
         $newTargetsData = TargetsMetadata::createFromJson($newTargetsContent, $role);
-        // TUF-SPEC-v1.0.15 Section 5.5.1
+        // TUF-SPEC-v1.0.16 Section 5.5.1
         $newSnapshotData->verifyNewHashes($newTargetsData);
-        // TUF-SPEC-v1.0.15 Section 5.5.2
+        // TUF-SPEC-v1.0.16 Section 5.5.2
         $this->checkSignatures($newTargetsData);
-        // TUF-SPEC-v1.0.15 Section 5.5.3
+        // TUF-SPEC-v1.0.16 Section 5.5.3
         $newSnapshotData->verifyNewVersion($newTargetsData);
-        // TUF-SPEC-v1.0.15 Section 5.5.4
+        // TUF-SPEC-v1.0.16 Section 5.5.4
         static::checkFreezeAttack($newTargetsData, $this->metadataExpiration);
         $newTargetsData->setIsTrusted(true);
-        // TUF-SPEC-v1.0.15 Section 5.5.5
+        // TUF-SPEC-v1.0.16 Section 5.5.5
         $this->durableStorage["$role.json"] = $newTargetsContent;
     }
 
     /**
-     * Creates the expiration date after which metadata will be considered expired.
+     * Returns the time that the update began.
      *
      * @return \DateTimeImmutable
-     *   The expiration date.
+     *   The time that the update began.
      */
-    protected function createExpirationDate(): \DateTimeImmutable
+    private function getUpdateStartTime(): \DateTimeImmutable
     {
         $fakeNow = '2020-01-01T00:00:00Z';
-        // Allow metadata that expires five minutes after ::refresh() starts.
-        $expirationAdditionInterval = \DateInterval::createFromDateString("5 minutes");
-        return static::metadataTimestampToDateTime($fakeNow)->add($expirationAdditionInterval);
+        return static::metadataTimestampToDateTime($fakeNow);
     }
 }

--- a/src/Key.php
+++ b/src/Key.php
@@ -61,7 +61,7 @@ final class Key
      *
      * @return static
      *
-     * @see https://github.com/theupdateframework/specification/blob/v1.0.15/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.16/tuf-spec.md#4-document-formats
      */
     public static function createFromMetadata(\ArrayObject $keyInfo): self
     {
@@ -104,7 +104,7 @@ final class Key
      * @return string
      *     The key ID in hex format for the key metadata hashed using sha256.
      *
-     * @see https://github.com/theupdateframework/specification/blob/v1.0.15/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.16/tuf-spec.md#4-document-formats
      *
      * @todo https://github.com/php-tuf/php-tuf/issues/56
      */

--- a/src/KeyDB.php
+++ b/src/KeyDB.php
@@ -42,7 +42,7 @@ class KeyDB
      * @throws \Tuf\Exception\InvalidKeyException
      *   Thrown if an unsupported or invalid key exists in the metadata.
      *
-     * @see https://github.com/theupdateframework/specification/blob/v1.0.15/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.16/tuf-spec.md#4-document-formats
      */
     public static function createFromRootMetadata(RootMetadata $rootMetadata, bool $allowUntrustedAccess = false): KeyDB
     {
@@ -90,7 +90,7 @@ class KeyDB
      *
      * @return void
      *
-     * @see https://github.com/theupdateframework/specification/blob/v1.0.15/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.16/tuf-spec.md#4-document-formats
      */
     public function addKey(string $keyId, Key $key): void
     {
@@ -119,7 +119,7 @@ class KeyDB
      * @throws \Tuf\Exception\NotFoundException
      *     Thrown if the key ID is not found in the keydb database.
      *
-     * @see https://github.com/theupdateframework/specification/blob/v1.0.15/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.16/tuf-spec.md#4-document-formats
      */
     public function getKey(string $keyId): Key
     {

--- a/src/Role.php
+++ b/src/Role.php
@@ -59,7 +59,7 @@ class Role
      *
      * @return static
      *
-     * @see https://github.com/theupdateframework/specification/blob/v1.0.15/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.16/tuf-spec.md#4-document-formats
      */
     public static function createFromMetadata(\ArrayObject $roleInfo, string $name): Role
     {

--- a/src/RoleDB.php
+++ b/src/RoleDB.php
@@ -34,7 +34,7 @@ class RoleDB
      * @throws \Exception
      *     Thrown if a threshold value in the metadata is not valid.
      *
-     * @see https://github.com/theupdateframework/specification/blob/v1.0.15/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.16/tuf-spec.md#4-document-formats
      */
     public static function createFromRootMetadata(RootMetadata $rootMetadata, bool $allowUntrustedAccess = false): RoleDB
     {
@@ -101,7 +101,7 @@ class RoleDB
      * @throws \Tuf\Exception\NotFoundException
      *     Thrown if the role does not exist.
      *
-     * @see https://github.com/theupdateframework/specification/blob/v1.0.15/tuf-spec.md#4-document-formats
+     * @see https://github.com/theupdateframework/specification/blob/v1.0.16/tuf-spec.md#4-document-formats
      */
     public function getRole(string $roleName): Role
     {

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -549,7 +549,7 @@ class UpdaterTest extends TestCase
             // the hashes specified in the timestamp.json. This is because timestamp.json in the test
             // fixtures contains the optional 'hashes' metadata for the snapshot.json files, and this
             // is checked before the file signatures and the file version number. The order of checking
-            // is specified in TUF-SPEC-v1.0.15 Section 5.5.
+            // is specified in TUF-SPEC-v1.0.16 Section 5.5.
             [
                 '5.snapshot.json',
                 ['signed', 'newkey'],


### PR DESCRIPTION
Update to v1.0.16 of the spec, according to `https://github.com/theupdateframework/specification/compare/v1.0.15...v1.0.16`.

I'm not even mad that it removes the idea of "fixed update expiration time" that we just implemented in #197. I removed the interval stuff and renamed the method to more accurately summarize what it's for.