### PR TITLE
Fix terminating delegated role logic

### DIFF
--- a/generate_fixtures.py
+++ b/generate_fixtures.py
@@ -230,15 +230,16 @@ class TUFTestFixtureNestedDelegated(TUFTestFixtureDelegated):
         (public_level_3_key, private_level_3key) = self.write_and_import_keypair(
             'targets_level_3_delegated')
 
-        # Add a delegation below level_2.
+        # Add a delegated role 'level_3' from role 'level_2'. For files in this delegation to be found
+        # the 'paths' property must also be compatible with the 'paths' property of 'level_2'
         level_2_delegation.delegate(
             'level_3', [public_level_3_key], ['level_1_2_3_*.txt'])
         self.write_and_add_target('level_1_2_3_below_non_terminating_target.txt', 'level_3')
         level_2_delegation('level_3').load_signing_key(
             private_level_3key)
 
-        # Add a delegation below level_2_terminating
-        # Delegations below a terminating delegation are evaluated but delegations after a terminating delegation
+        # Add a delegation below the 'level_2_terminating' role.
+        # Delegations from a terminating role are evaluated but delegations after a terminating delegation
         # are not.
         # See TUFTestFixtureNestedDelegatedErrors
         level_2_terminating_delegation = self.repository.targets._delegated_roles.get('level_2_terminating')

--- a/generate_fixtures.py
+++ b/generate_fixtures.py
@@ -249,24 +249,25 @@ class TUFTestFixtureNestedDelegatedErrors(TUFTestFixtureNestedDelegated):
 
         level_1_delegation = self.repository.targets._delegated_roles.get('unclaimed')
 
-        # Delegate from level_1_delegation to level_1 target-signing key
-        (public_level_2_error_key, private_level_2_error_key) = self.write_and_import_keypair(
-            'targets_level_2_error')
+        # Add a target that does not match the delegations pathes.
+        self.write_and_add_target('level_2_unfindable.txt', 'level_2_terminating')
 
-        # Add a delegation that does not match the pattern of level_1 delegation
-        # Nothing in this delegation should be found.
+        (public_level_2_after_terminating_key, private_level_2_after_terminating_key) = self.write_and_import_keypair(
+            'targets_level_2_after_terminating')
+
+        # Add a delegation after level_2_terminating which will not be evaluted.
         level_1_delegation.delegate(
-            'level_2_error', [public_level_2_error_key], ['level_2_*.txt'])
-        self.write_and_add_target('level_2_unfindable.txt', 'level_2_error')
+            'level_2_after_terminating', [public_level_2_after_terminating_key], ['level_2_*.txt'])
+        self.write_and_add_target('level_2_after_terminating_unfindable.txt', 'level_2_after_terminating')
         level_1_delegation('level_2').load_signing_key(
-            private_level_2_error_key)
+            private_level_2_after_terminating_key)
 
         level_2_terminating_delegation = self.repository.targets._delegated_roles.get('level_2_terminating')
         (public_level_3_below_terminated_key, private_level_3_below_terminated_key) = self.write_and_import_keypair(
             'targets_level_3_below_terminated')
         level_2_terminating_delegation.delegate(
-            'level_3_below_terminated', [public_level_3_below_terminated_key], ['level_1_2_terminating_unfindable_*.txt'])
-        self.write_and_add_target('level_1_2_terminating_unfindable_target.txt', 'level_3_below_terminated')
+            'level_3_below_terminated', [public_level_3_below_terminated_key], ['level_1_2_3_*.txt'])
+        self.write_and_add_target('level_1_2_3_target.txt', 'level_3_below_terminated')
         level_2_terminating_delegation('level_3_below_terminated').load_signing_key(
             private_level_3_below_terminated_key)
 

--- a/generate_fixtures.py
+++ b/generate_fixtures.py
@@ -230,12 +230,25 @@ class TUFTestFixtureNestedDelegated(TUFTestFixtureDelegated):
         (public_level_3_key, private_level_3key) = self.write_and_import_keypair(
             'targets_level_3_delegated')
 
-        # Add a delegation that matches the path pattern 'test_nested2_*.txt'
+        # Add a delegation below level_2.
         level_2_delegation.delegate(
             'level_3', [public_level_3_key], ['level_1_2_3_*.txt'])
-        self.write_and_add_target('level_1_2_3_target.txt', 'level_3')
+        self.write_and_add_target('level_1_2_3_below_non_terminating_target.txt', 'level_3')
         level_2_delegation('level_3').load_signing_key(
             private_level_3key)
+
+        # Add a delegation below level_2_terminating
+        # Delegations below a terminating delegation are evaluated but delegations after a terminating delegation
+        # are not.
+        # See TUFTestFixtureNestedDelegatedErrors
+        level_2_terminating_delegation = self.repository.targets._delegated_roles.get('level_2_terminating')
+        (public_level_3_below_terminated_key, private_level_3_below_terminated_key) = self.write_and_import_keypair(
+            'targets_level_3_below_terminated')
+        level_2_terminating_delegation.delegate(
+            'level_3_below_terminated', [public_level_3_below_terminated_key], ['level_1_2_terminating_3_*.txt'])
+        self.write_and_add_target('level_1_2_terminating_3_target.txt', 'level_3_below_terminated')
+        level_2_terminating_delegation('level_3_below_terminated').load_signing_key(
+            private_level_3_below_terminated_key)
 
         self.write_and_publish_repository(export_client=False)
 
@@ -261,15 +274,6 @@ class TUFTestFixtureNestedDelegatedErrors(TUFTestFixtureNestedDelegated):
         self.write_and_add_target('level_2_after_terminating_unfindable.txt', 'level_2_after_terminating')
         level_1_delegation('level_2').load_signing_key(
             private_level_2_after_terminating_key)
-
-        level_2_terminating_delegation = self.repository.targets._delegated_roles.get('level_2_terminating')
-        (public_level_3_below_terminated_key, private_level_3_below_terminated_key) = self.write_and_import_keypair(
-            'targets_level_3_below_terminated')
-        level_2_terminating_delegation.delegate(
-            'level_3_below_terminated', [public_level_3_below_terminated_key], ['level_1_2_3_*.txt'])
-        self.write_and_add_target('level_1_2_3_target.txt', 'level_3_below_terminated')
-        level_2_terminating_delegation('level_3_below_terminated').load_signing_key(
-            private_level_3_below_terminated_key)
 
         self.write_and_publish_repository(export_client=False)
 

--- a/generate_fixtures.py
+++ b/generate_fixtures.py
@@ -263,7 +263,7 @@ class TUFTestFixtureNestedDelegatedErrors(TUFTestFixtureNestedDelegated):
 
         level_1_delegation = self.repository.targets._delegated_roles.get('unclaimed')
 
-        # Add a target that does not match the delegations pathes.
+        # Add a target that does not match the delegation's paths.
         self.write_and_add_target('level_2_unfindable.txt', 'level_2_terminating')
 
         (public_level_2_after_terminating_key, private_level_2_after_terminating_key) = self.write_and_import_keypair(

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -624,14 +624,17 @@ class Updater
             if ($newTargetsData->hasTarget($target)) {
                 return $newTargetsData;
             }
+            // TUF-SPEC-v1.0.16 Section 5.5.6.2.1
+            //  If the current delegation is a multi-role delegation, recursively visit each role, and check that each has signed exactly the same non-custom metadata (i.e., length and hashes) about the target (or the lack of any such metadata).
+            // @todo confirm we should recursively search roles even if the current role is terminating????????
+            if ($matchingTargetMetadata = $this->getMetadataForTarget($target, $newTargetsData, $searchedRoles)) {
+                return $matchingTargetMetadata;
+            }
             if ($delegatedRole->isTerminating()) {
                 // TUF-SPEC-v1.0.16 Section 5.5.6.2.2
                 // If the role is terminating then abort searching for a target.
                 // @todo Add test coverage in this PR.
                 return null;
-            }
-            if ($matchingTargetMetadata = $this->getMetadataForTarget($target, $newTargetsData, $searchedRoles)) {
-                return $matchingTargetMetadata;
             }
         }
         return null;

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -649,14 +649,12 @@ class Updater
             }
             // TUF-SPEC-v1.0.16 Section 5.5.6.2.1
             //  If the current delegation is a multi-role delegation, recursively visit each role, and check that each has signed exactly the same non-custom metadata (i.e., length and hashes) about the target (or the lack of any such metadata).
-            // @todo confirm we should recursively search roles even if the current role is terminating????????
             if ($matchingTargetMetadata = $this->getMetadataForTarget($target, $newTargetsData, $searchedRoles)) {
                 return $matchingTargetMetadata;
             }
             if ($delegatedRole->isTerminating()) {
                 // TUF-SPEC-v1.0.16 Section 5.5.6.2.2
                 // If the role is terminating then abort searching for a target.
-                // @todo Add test coverage in this PR.
                 return null;
             }
         }

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -625,8 +625,10 @@ class Updater
                 return $newTargetsData;
             }
             if ($delegatedRole->isTerminating()) {
-                // If the role is terminating then we do not search this targets metadata for additional delegations.
-                continue;
+                // TUF-SPEC-v1.0.16 Section 5.5.6.2.2
+                // If the role is terminating then abort searching for a target.
+                // @todo Add test coverage in this PR.
+                return null;
             }
             if ($matchingTargetMetadata = $this->getMetadataForTarget($target, $newTargetsData, $searchedRoles)) {
                 return $matchingTargetMetadata;

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -269,6 +269,7 @@ class UpdaterTest extends TestCase
         foreach ($expectedClientVersionsAfterDownloads as $delegatedFile => $expectedClientVersions) {
             $testFilePath = static::getFixturesRealPath($fixturesSet, "tufrepo/targets/$delegatedFile", false);
             $testFileContents = file_get_contents($testFilePath);
+            self::assertNotEmpty($testFileContents);
             $this->assertSame($testFileContents, $updater->download($delegatedFile)->wait()->getContents());
             $this->assertClientRepoVersions($expectedClientVersions);
         }
@@ -320,11 +321,12 @@ class UpdaterTest extends TestCase
             // 'paths' property is incompatible with the its parent delegation's
             // 'paths' property.
             'delegated path does not match parent' => ['level_2_unfindable.txt'],
-            // ''level_1_2_terminating_unfindable_target.txt' is add via role
-            // 'level_3_below_terminated' which is delegated from role 'level_2_terminating'.
-            // Because 'level_2_terminating' is terminating role no roles it delegates to
-            // should be evaluated.
-            'parent delegation is terminating' => ['level_1_2_terminating_unfindable_target.txt']
+            // 'level_2_after_terminating_unfindable.txt' is added via role
+            // 'level_2_after_terminating' which is delegated from role at the same level as 'level_2_terminating'
+            //  but added after 'level_2_terminating'.
+            // Because 'level_2_terminating' is a terminating role its own delegations are evaluated but no other
+            // delegations are evaluated after it.
+            'delegation is after terminating delegation' => ['level_2_after_terminating_unfindable.txt'],
         ];
     }
 

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -265,6 +265,8 @@ class UpdaterTest extends TestCase
                 'level_2_terminating' => 1,
                 'level_3' => 1,
             ],
+            // Roles delegated from a terminating role are evaluated.
+            // See TUF-SPEC-v1.0.16 Section 5.5.6.2.1 and 5.5.6.2.2.
             'level_1_2_terminating_3_target.txt' => [
                 'root' => 6,
                 'timestamp' => 6,
@@ -337,6 +339,7 @@ class UpdaterTest extends TestCase
             //  but added after 'level_2_terminating'.
             // Because 'level_2_terminating' is a terminating role its own delegations are evaluated but no other
             // delegations are evaluated after it.
+            // See TUF-SPEC-v1.0.16 Section 5.5.6.2.1 and 5.5.6.2.2.
             'delegation is after terminating delegation' => ['level_2_after_terminating_unfindable.txt'],
         ];
     }

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -255,7 +255,7 @@ class UpdaterTest extends TestCase
                 'level_2_terminating' => 1,
                 'level_3' => null,
             ],
-            'level_1_2_3_target.txt' => [
+            'level_1_2_3_below_non_terminating_target.txt' => [
                 'root' => 6,
                 'timestamp' => 6,
                 'snapshot' => 6,
@@ -264,6 +264,17 @@ class UpdaterTest extends TestCase
                 'level_2' => 1,
                 'level_2_terminating' => 1,
                 'level_3' => 1,
+            ],
+            'level_1_2_terminating_3_target.txt' => [
+                'root' => 6,
+                'timestamp' => 6,
+                'snapshot' => 6,
+                'targets' => 6,
+                'unclaimed' => 2,
+                'level_2' => 1,
+                'level_2_terminating' => 1,
+                'level_3' => 1,
+                'level_3_below_terminated' => 1,
             ],
         ];
         foreach ($expectedClientVersionsAfterDownloads as $delegatedFile => $expectedClientVersions) {


### PR DESCRIPTION
initially when I created getMetadataForTarget() I read the spec wrong and thought if the a role is terminating you don't search more of that delegation tree. But actually this abort the search for the metadata. SEe 5.5.6.2.2 in https://github.com/theupdateframework/specification/blob/v1.0.16/tuf-spec.md

This still needs tests