### PR TITLE
Create a factory class for loading trusted metadata

### DIFF
--- a/src/Metadata/Factory.php
+++ b/src/Metadata/Factory.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tuf\Metadata;
+
+/**
+ * Provides methods to load value objects for trusted metadata.
+ */
+class Factory
+{
+    /**
+     * The persistent storage backend for trusted metadata.
+     *
+     * @var \ArrayAccess
+     */
+    protected $storage;
+
+    /**
+     * Factory constructor.
+     *
+     * @param \ArrayAccess $storage
+     *   The persistent storage backend.
+     */
+    public function __construct(\ArrayAccess $storage)
+    {
+        $this->storage = $storage;
+    }
+
+    /**
+     * Loads a value object for trusted metadata.
+     *
+     * @param string $role
+     *   The role to be loaded.
+     *
+     * @return \Tuf\Metadata\MetadataBase|null
+     *   The trusted metadata for the role, or NULL if none was found.
+     */
+    public function load(string $role): ?MetadataBase
+    {
+        $fileName = "$role.json";
+        if (isset($this->storage[$fileName])) {
+            $json = $this->storage[$fileName];
+            switch ($role) {
+                case RootMetadata::TYPE:
+                    $currentMetadata = RootMetadata::createFromJson($json);
+                    break;
+                case SnapshotMetadata::TYPE:
+                    $currentMetadata = SnapshotMetadata::createFromJson($json);
+                    break;
+                case TimestampMetadata::TYPE:
+                    $currentMetadata = TimestampMetadata::createFromJson($json);
+                    break;
+                default:
+                    $currentMetadata = TargetsMetadata::createFromJson($json);
+            }
+            $currentMetadata->setIsTrusted(true);
+            return $currentMetadata;
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/Metadata/RootMetadata.php
+++ b/src/Metadata/RootMetadata.php
@@ -18,7 +18,7 @@ class RootMetadata extends MetadataBase
     /**
      * {@inheritdoc}
      */
-    protected const TYPE = 'root';
+    public const TYPE = 'root';
 
     /**
      * {@inheritdoc}

--- a/src/Metadata/SnapshotMetadata.php
+++ b/src/Metadata/SnapshotMetadata.php
@@ -15,7 +15,7 @@ class SnapshotMetadata extends MetadataBase
     /**
      * {@inheritdoc}
      */
-    protected const TYPE = 'snapshot';
+    public const TYPE = 'snapshot';
 
     /**
      * {@inheritdoc}

--- a/src/Metadata/TargetsMetadata.php
+++ b/src/Metadata/TargetsMetadata.php
@@ -20,7 +20,7 @@ class TargetsMetadata extends MetadataBase
     /**
      * {@inheritdoc}
      */
-    protected const TYPE = 'targets';
+    public const TYPE = 'targets';
 
     /**
      * The role name if different from the type.

--- a/src/Metadata/TimestampMetadata.php
+++ b/src/Metadata/TimestampMetadata.php
@@ -16,7 +16,7 @@ class TimestampMetadata extends MetadataBase
     /**
      * {@inheritdoc}
      */
-    protected const TYPE = 'timestamp';
+    public const TYPE = 'timestamp';
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
This is split off from @tedbow's work in #206. IMHO it makes sense for us to have a metadata factory class, which knows how to load trusted metadata from the persistent storage backend. Later on, we can add a method that also loads the appropriate verifier class for the given role.