### PR TITLE
Do not allow metadata to be set as untrusted after they are set as trusted

### DIFF
--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -221,7 +221,7 @@ class Updater
 
         // TUF-SPEC-v1.0.16 Section 5.4.6
         $this->durableStorage['snapshot.json'] = $newSnapshotContents;
-        $newSnapshotData->setIsTrusted(true);
+        $newSnapshotData->setTrusted();
 
         // TUF-SPEC-v1.0.16 Section 5.5
         if ($rootData->supportsConsistentSnapshots()) {
@@ -258,7 +258,7 @@ class Updater
 
         // § 5.3.4: Persist timestamp metadata
         $this->durableStorage['timestamp.json'] = $newTimestampContents;
-        $newTimestampData->setIsTrusted(true);
+        $newTimestampData->setTrusted();
 
         return $newTimestampData;
     }
@@ -407,7 +407,7 @@ class Updater
             // *TUF-SPEC-v1.0.12 Section 5.2.4
 
             static::checkRollbackAttack($rootData, $nextRoot, $nextVersion);
-            $nextRoot->setIsTrusted(true);
+            $nextRoot->setTrusted();
             $rootData = $nextRoot;
             // *TUF-SPEC-v1.0.16 Section 5.2.5 - Needs no action.
             // Note that the expiration of the new (intermediate) root metadata
@@ -682,7 +682,7 @@ class Updater
         $newSnapshotData->verifyNewVersion($newTargetsData);
         // TUF-SPEC-v1.0.16 Section 5.5.4
         static::checkFreezeAttack($newTargetsData, $this->metadataExpiration);
-        $newTargetsData->setIsTrusted(true);
+        $newTargetsData->setTrusted();
         // TUF-SPEC-v1.0.16 Section 5.5.5
         $this->durableStorage["$role.json"] = $newTargetsContent;
     }

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -221,7 +221,7 @@ class Updater
 
         // TUF-SPEC-v1.0.16 Section 5.4.6
         $this->durableStorage['snapshot.json'] = $newSnapshotContents;
-        $newSnapshotData->setTrusted();
+        $newSnapshotData->trust();
 
         // TUF-SPEC-v1.0.16 Section 5.5
         if ($rootData->supportsConsistentSnapshots()) {
@@ -258,7 +258,7 @@ class Updater
 
         // § 5.3.4: Persist timestamp metadata
         $this->durableStorage['timestamp.json'] = $newTimestampContents;
-        $newTimestampData->setTrusted();
+        $newTimestampData->trust();
 
         return $newTimestampData;
     }
@@ -407,7 +407,7 @@ class Updater
             // *TUF-SPEC-v1.0.12 Section 5.2.4
 
             static::checkRollbackAttack($rootData, $nextRoot, $nextVersion);
-            $nextRoot->setTrusted();
+            $nextRoot->trust();
             $rootData = $nextRoot;
             // *TUF-SPEC-v1.0.16 Section 5.2.5 - Needs no action.
             // Note that the expiration of the new (intermediate) root metadata
@@ -682,7 +682,7 @@ class Updater
         $newSnapshotData->verifyNewVersion($newTargetsData);
         // TUF-SPEC-v1.0.16 Section 5.5.4
         static::checkFreezeAttack($newTargetsData, $this->metadataExpiration);
-        $newTargetsData->setTrusted();
+        $newTargetsData->trust();
         // TUF-SPEC-v1.0.16 Section 5.5.5
         $this->durableStorage["$role.json"] = $newTargetsContent;
     }

--- a/src/Metadata/Factory.php
+++ b/src/Metadata/Factory.php
@@ -52,7 +52,7 @@ class Factory
                 default:
                     $currentMetadata = TargetsMetadata::createFromJson($json);
             }
-            $currentMetadata->setTrusted();
+            $currentMetadata->trust();
             return $currentMetadata;
         } else {
             return null;

--- a/src/Metadata/Factory.php
+++ b/src/Metadata/Factory.php
@@ -52,7 +52,7 @@ class Factory
                 default:
                     $currentMetadata = TargetsMetadata::createFromJson($json);
             }
-            $currentMetadata->setIsTrusted(true);
+            $currentMetadata->setTrusted();
             return $currentMetadata;
         } else {
             return null;

--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -220,15 +220,8 @@ abstract class MetadataBase
     }
 
     /**
-     * @return boolean
-     *    Whether the metadata is trusted.
-     */
-    public function isTrusted(): bool
-    {
-        return $this->isTrusted;
-    }
-
-    /**
+     * Sets the metadata as trusted.
+     *
      * @return void
      */
     public function setTrusted(): void
@@ -246,7 +239,7 @@ abstract class MetadataBase
      */
     protected function ensureIsTrusted(bool $allowUntrustedAccess = false): void
     {
-        if (!$allowUntrustedAccess && !$this->isTrusted()) {
+        if (!$allowUntrustedAccess && !$this->isTrusted) {
             throw new \RuntimeException("Cannot use untrusted '{$this->getRole()}'. metadata.");
         }
     }

--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -229,14 +229,11 @@ abstract class MetadataBase
     }
 
     /**
-     * @param boolean $isTrusted
-     *   Whether the metadata should be trusted.
-     *
      * @return void
      */
-    public function setIsTrusted(bool $isTrusted): void
+    public function setTrusted(): void
     {
-        $this->isTrusted = $isTrusted;
+        $this->isTrusted = true;
     }
 
     /**

--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -224,7 +224,7 @@ abstract class MetadataBase
      *
      * @return void
      */
-    public function setTrusted(): void
+    public function trust(): void
     {
         $this->isTrusted = true;
     }

--- a/tests/KeyDBTest.php
+++ b/tests/KeyDBTest.php
@@ -27,7 +27,7 @@ class KeyDBTest extends TestCase
         );
         $rootMetadata = RootMetadata::createFromJson(file_get_contents($rootJsonPath));
         self::assertInstanceOf(RootMetadata::class, $rootMetadata);
-        $rootMetadata->setTrusted();
+        $rootMetadata->trust();
         $keyDb = KeyDB::createFromRootMetadata($rootMetadata);
         self::assertInstanceOf(KeyDB::class, $keyDb);
         // Get the first key for comparison.

--- a/tests/KeyDBTest.php
+++ b/tests/KeyDBTest.php
@@ -27,7 +27,7 @@ class KeyDBTest extends TestCase
         );
         $rootMetadata = RootMetadata::createFromJson(file_get_contents($rootJsonPath));
         self::assertInstanceOf(RootMetadata::class, $rootMetadata);
-        $rootMetadata->setIsTrusted(true);
+        $rootMetadata->setTrusted();
         $keyDb = KeyDB::createFromRootMetadata($rootMetadata);
         self::assertInstanceOf(KeyDB::class, $keyDb);
         // Get the first key for comparison.

--- a/tests/Metadata/RootMetadataTest.php
+++ b/tests/Metadata/RootMetadataTest.php
@@ -152,7 +152,7 @@ class RootMetadataTest extends MetadataBaseTest
             $data['signed']['consistent_snapshot'] = $value;
             /** @var \Tuf\Metadata\RootMetadata $metadata */
             $metadata = static::callCreateFromJson(json_encode($data));
-            $metadata->setTrusted();
+            $metadata->trust();
             $this->assertSame($value, $metadata->supportsConsistentSnapshots());
         }
 
@@ -189,7 +189,7 @@ class RootMetadataTest extends MetadataBaseTest
         $data = json_decode($json, true);
         /** @var \Tuf\Metadata\RootMetadata $metadata */
         $metadata = static::callCreateFromJson($json);
-        $metadata->setTrusted();
+        $metadata->trust();
         $expectRoleNames = ['root', 'snapshot', 'targets', 'timestamp'];
         $roles = $metadata->getRoles();
         self::assertCount(4, $roles);

--- a/tests/Metadata/RootMetadataTest.php
+++ b/tests/Metadata/RootMetadataTest.php
@@ -152,7 +152,7 @@ class RootMetadataTest extends MetadataBaseTest
             $data['signed']['consistent_snapshot'] = $value;
             /** @var \Tuf\Metadata\RootMetadata $metadata */
             $metadata = static::callCreateFromJson(json_encode($data));
-            $metadata->setIsTrusted(true);
+            $metadata->setTrusted();
             $this->assertSame($value, $metadata->supportsConsistentSnapshots());
         }
 
@@ -189,7 +189,7 @@ class RootMetadataTest extends MetadataBaseTest
         $data = json_decode($json, true);
         /** @var \Tuf\Metadata\RootMetadata $metadata */
         $metadata = static::callCreateFromJson($json);
-        $metadata->setIsTrusted(true);
+        $metadata->setTrusted();
         $expectRoleNames = ['root', 'snapshot', 'targets', 'timestamp'];
         $roles = $metadata->getRoles();
         self::assertCount(4, $roles);


### PR DESCRIPTION
Currently `\Tuf\Metadata\MetadataBase::setIsTrusted()` allows you to mark metadata as trusted or untrusted.

But there is no reason you would keep metadata object around if you knew it was untrusted. All of our calls to this pass true.

We verify and mark as trusted. You should not be able to mark as untrusted. Untrusted is the default state until the metadata is verified.

