### PR TITLE
Fix snapshot rollback to not check version in previous snapshot file

### DIFF
--- a/src/Metadata/Verifier/FileInfoVerifier.php
+++ b/src/Metadata/Verifier/FileInfoVerifier.php
@@ -33,8 +33,7 @@ abstract class FileInfoVerifier extends VerifierBase
         $type = $this->trustedMetadata->getType();
         foreach ($localMetaFileInfos as $fileName => $localFileInfo) {
             /** @var \Tuf\Metadata\SnapshotMetadata|\Tuf\Metadata\TimestampMetadata $untrustedMetadata */
-            if ($remoteFileInfo = $untrustedMetadata->getFileMetaInfo($fileName,
-              true)) {
+            if ($remoteFileInfo = $untrustedMetadata->getFileMetaInfo($fileName, true)) {
                 if ($remoteFileInfo['version'] < $localFileInfo['version']) {
                     $message = "Remote $type metadata file '$fileName' version \"${$remoteFileInfo['version']}\" " .
                       "is less than previously seen  version \"${$localFileInfo['version']}\"";

--- a/src/Metadata/Verifier/FileInfoVerifier.php
+++ b/src/Metadata/Verifier/FileInfoVerifier.php
@@ -3,7 +3,7 @@
 namespace Tuf\Metadata\Verifier;
 
 use Tuf\Exception\PotentialAttackException\RollbackAttackException;
-use Tuf\Metadata\MetadataBase;
+use Tuf\Metadata\FileInfoMetadataBase;
 
 /**
  * Verifier for metadata classes that have information about other files.
@@ -17,12 +17,14 @@ abstract class FileInfoVerifier extends VerifierBase
      */
     protected $trustedMetadata;
 
+
     /**
-     * {@inheritdoc}
+     * @param \Tuf\Metadata\TimestampMetadata $untrustedMetadata
+     *
+     * @throws \Tuf\Exception\PotentialAttackException\RollbackAttackException
      */
-    protected function checkRollbackAttack(MetadataBase $untrustedMetadata): void
+    protected function checkFileInfoVersions(FileInfoMetadataBase $untrustedMetadata): void
     {
-        parent::checkRollbackAttack($untrustedMetadata);
         // Check that all files in the trusted/local metadata info under the 'meta' section are less or equal to
         // the same files in the new metadata info.
         // For 'snapshot' type this is TUF-SPEC-v1.0.16 Section 5.4.4
@@ -31,7 +33,8 @@ abstract class FileInfoVerifier extends VerifierBase
         $type = $this->trustedMetadata->getType();
         foreach ($localMetaFileInfos as $fileName => $localFileInfo) {
             /** @var \Tuf\Metadata\SnapshotMetadata|\Tuf\Metadata\TimestampMetadata $untrustedMetadata */
-            if ($remoteFileInfo = $untrustedMetadata->getFileMetaInfo($fileName, true)) {
+            if ($remoteFileInfo = $untrustedMetadata->getFileMetaInfo($fileName,
+              true)) {
                 if ($remoteFileInfo['version'] < $localFileInfo['version']) {
                     $message = "Remote $type metadata file '$fileName' version \"${$remoteFileInfo['version']}\" " .
                       "is less than previously seen  version \"${$localFileInfo['version']}\"";

--- a/src/Metadata/Verifier/FileInfoVerifier.php
+++ b/src/Metadata/Verifier/FileInfoVerifier.php
@@ -19,7 +19,10 @@ abstract class FileInfoVerifier extends VerifierBase
 
 
     /**
-     * @param \Tuf\Metadata\TimestampMetadata $untrustedMetadata
+     * Checks for rollback of files referenced in $untrustedMetadata.
+     *
+     * @param \Tuf\Metadata\FileInfoMetadataBase $untrustedMetadata
+     *     The untrusted metadata.
      *
      * @throws \Tuf\Exception\PotentialAttackException\RollbackAttackException
      */

--- a/src/Metadata/Verifier/SnapshotVerifier.php
+++ b/src/Metadata/Verifier/SnapshotVerifier.php
@@ -62,12 +62,13 @@ class SnapshotVerifier extends FileInfoVerifier
      */
     protected function checkRollbackAttack(MetadataBase $untrustedMetadata): void
     {
-        parent::checkRollbackAttack($untrustedMetadata);
+        // TUF-SPEC-v1.0.16 Section 5.4.4
+        /** @var TimestampMetadata $untrustedMetadata */
+        $this->checkFileInfoVersions($untrustedMetadata);
         $localMetaFileInfos = $this->trustedMetadata->getSigned()['meta'];
         foreach ($localMetaFileInfos as $fileName => $localFileInfo) {
             /** @var \Tuf\Metadata\SnapshotMetadata|\Tuf\Metadata\TimestampMetadata $untrustedMetadata */
             if (!$untrustedMetadata->getFileMetaInfo($fileName, true)) {
-                // TUF-SPEC-v1.0.16 Section 5.4.4
                 // Any targets metadata filename that was listed in the trusted snapshot metadata file, if any, MUST
                 // continue to be listed in the new snapshot metadata file.
                 throw new RollbackAttackException("Remote snapshot metadata file references '$fileName' but this is not present in the remote file");

--- a/src/Metadata/Verifier/TimestampVerifier.php
+++ b/src/Metadata/Verifier/TimestampVerifier.php
@@ -25,4 +25,18 @@ class TimestampVerifier extends FileInfoVerifier
         // § 5.3.3
         static::checkFreezeAttack($untrustedMetadata, $this->metadataExpiration);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function checkRollbackAttack(MetadataBase $untrustedMetadata): void
+    {
+        // § 5.3.2.1
+        parent::checkRollbackAttack($untrustedMetadata);
+        // § 5.3.2.2
+        /** @var \Tuf\Metadata\SnapshotMetadata $untrustedMetadata */
+        $this->checkFileInfoVersions($untrustedMetadata);
+    }
+
+
 }

--- a/src/Metadata/Verifier/TimestampVerifier.php
+++ b/src/Metadata/Verifier/TimestampVerifier.php
@@ -37,6 +37,4 @@ class TimestampVerifier extends FileInfoVerifier
         /** @var \Tuf\Metadata\SnapshotMetadata $untrustedMetadata */
         $this->checkFileInfoVersions($untrustedMetadata);
     }
-
-
 }


### PR DESCRIPTION
Currently `SnapshotVerifier` and `TimestampVerifier` both extend `FileInfoVerifier`. 

They do this because they both share some logic in checking for rollback attacks, so we have `FileInfoVerifier::checkRollbackAttack()`

This method calls `parent::checkRollbackAttack($untrustedMetadata);` which is `VerifierBase::checkRollbackAttack()` which just checks that new version is not less than the trusted version of the same type.

This seems reasonable but in reviewing #213 I realized that for snapshot the `VerifierBase::checkRollbackAttack()` doesn't apply. It won't break anything to do it but it is not actually in the spec.

Instead it has:
1. **5.4.3. Check against timestamp role's snapshot version.** which we do in 
```
// TUF-SPEC-v1.0.16 Section 5.4.3
$this->checkAgainstVersionFromTrustedAuthority($untrustedMetadata);
```

2.  **5.4.4. Check for a rollback attack** which does **not** check the version number of snapshot against the previous version. This is because we have checked it is exactly the version specified in `timestamp`.

So `SnapshotVerifier` should **not** be calling the logic in ``VerifierBase::checkRollbackAttack()`

I have changed `FileInfoVerifier::checkRollbackAttack()` to `FileInfoVerifier::checkFileInfoVersions` because this is the logic that is shared between `Timestamp` and `Snapshot`

This makes me think maybe `FileInfoVerifier` should be a trait and not a base class but I have not changed that yet.