### PR TITLE
Make target files names describe the test case and clean up comments.

### DIFF
--- a/generate_fixtures.py
+++ b/generate_fixtures.py
@@ -259,8 +259,8 @@ class TUFTestFixtureNestedDelegatedErrors(TUFTestFixtureNestedDelegated):
 
         level_1_delegation = self.repository.targets._delegated_roles.get('unclaimed')
 
-        # Add a target that does not match the delegation's paths.
-        self.write_and_add_target('level_2_unfindable.txt', 'level_2_terminating')
+        # Add a target that does not match paths for the parent role and role it was add for.
+        self.write_and_add_target('level_2_non-matching-parent-and-direct-role.txt', 'level_2_terminating')
 
         # Add a delegation after level_2_terminating which will not be evaluated.
         self.delegate_role_with_file(delegator_role=level_1_delegation,

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -327,6 +327,7 @@ class UpdaterTest extends TestCase
         $this->testRepo = new TestRepo($fixturesSet);
         $updater = $this->getSystemInTest();
         $testFilePath = static::getFixturesRealPath($fixturesSet, "tufrepo/targets/$fileName", false);
+        self::assertTrue(file_exists($testFilePath));
         self::expectException(NotFoundException::class);
         self::expectExceptionMessage("Target not found: $fileName");
         $updater->download($fileName)->wait();
@@ -351,14 +352,12 @@ class UpdaterTest extends TestCase
             // 'unclaimed' role which has `paths: ['level_1_*.txt']`. The file matches
             // for the 'unclaimed' role but does not match for the 'level_2' role.
             'matches parent delegation' => ['level_1_3_target.txt'],
-            // 'level_2_unfindable.txt' is added via the 'level_2_error' role which has
-            // `paths: ['level_2_*.txt']`. The 'level_2_error' role is delegated from the
-            // 'unclaimed' role which has `paths: ['level_1_*.txt']`. The file matches
-            // for the 'level_2_error' role but does not match for the 'unclaimed' role.
-            // No files added via the 'level_2_error' role will be found because its
-            // 'paths' property is incompatible with the its parent delegation's
-            // 'paths' property.
-            'delegated path does not match parent' => ['level_2_unfindable.txt'],
+            // Test case file that does not match parent role and direct role paths.
+            // 'level_2_non-matching-parent-and-direct-role.txt' add via role 'level_2_terminating'
+            // 'level_2_terminating': paths = [''level_1_2_terminating_*.txt']
+            // 'level_2_terminating' delegated from 'unclaimed' role
+            // 'unclaimed' role': paths = ['level_1_*.txt']
+            'delegated path does not match parent' => ['level_2_non-matching-parent-and-direct-role.txt'],
             // 'level_2_after_terminating_unfindable.txt' is added via role
             // 'level_2_after_terminating' which is delegated from role at the same level as 'level_2_terminating'
             //  but added after 'level_2_terminating'.


### PR DESCRIPTION
In `generate_fixtures.py`  we have 

 ```
# Add a target that does not match the delegation's paths.
 self.write_and_add_target('level_2_unfindable.txt', 'level_2_terminating')
```
but this doesn't fully describe the situation.  'level_2_unfindable.txt' does not match the path for the role it was added from **and** it does not add match the parent role's path. This could have happen in combo of a PRs.

The comment on `\Tuf\Tests\Client\UpdaterTest::providerDelegationErrors()`  is also not clear:

```
// 'level_2_unfindable.txt' is added via the 'level_2_error' role which has
// `paths: ['level_2_*.txt']`. The 'level_2_error' role is delegated from the
 // 'unclaimed' role which has `paths: ['level_1_*.txt']`. The file matches
 // for the 'level_2_error' role but does not match for the 'unclaimed' role.
 // No files added via the 'level_2_error' role will be found because its
// 'paths' property is incompatible with the its parent delegation's
 // 'paths' property.
```
This is also not accurate 'level_2_error' has since been renamed the path is not different.

In this PR we should 
1. rename target files to describe the test case so file above would be changed to **level_2_non-matching-parent-and-direct-role.txt**
2. Update the comments to make sure they accurately describe the test case. I think would be better to not use sentence for the whole description. Rather something like this

```
// Test case: file that does not match parent role and direct role paths.
 // 'level_2_non-matching-parent-and-direct-role.txt' add via role 'level_2_terminating'
 // 'level_2_terminating': paths = [''level_1_2_terminating_*.txt']
 // 'level_2_terminating' delegated from 'unclaimed' role
 // 'unclaimed' role': paths = ['level_1_*.txt']
```

so describe the test case in words then document the roles and paths.
