### PR TITLE
Add extra arguments to testDelegationErrors() 

### DIFF
--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -424,8 +424,8 @@ class UpdaterTest extends TestCase
             // See § 5.6.7.2.1 and 5.6.7.2.2.
             'delegation is after terminating delegation' => [
                 'TUFTestFixtureNestedDelegatedErrors',
-                // @todo file file name in https://github.com/php-tuf/php-tuf/pull/216 becauses it does match the
-                // 'paths' property for 'unclaimed' and therefore cannot be find.
+                // @todo file file name in https://github.com/php-tuf/php-tuf/pull/216 becauses it does NOT match the
+                // 'paths' property for 'unclaimed' and therefore cannot be find not only for the reason state above.
                 'level_2_after_terminating_unfindable.txt',
                 [
                     'root' => 6,

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -330,9 +330,14 @@ class UpdaterTest extends TestCase
         $updater = $this->getSystemInTest();
         $testFilePath = static::getFixturesRealPath($fixturesSet, "server/targets/$fileName", false);
         self::assertFileExists($testFilePath);
-        self::expectException(NotFoundException::class);
-        self::expectExceptionMessage("Target not found: $fileName");
-        $updater->download($fileName)->wait();
+        try {
+            $updater->download($fileName)->wait();
+        } catch (NotFoundException $exception) {
+            self::assertEquals("Target not found: $fileName", $exception->getMessage());
+            $this->assertClientRepoVersions($expectedClientVersions);
+            return;
+        }
+        self::fail('NotFoundException not thrown.');
     }
 
     /**
@@ -349,18 +354,42 @@ class UpdaterTest extends TestCase
             // 'level_a.txt' is added via the 'unclaimed' role but this role has
             // `paths: ['level_1_*.txt']` which does not match the file name.
             'no path match' => [
-              'TUFTestFixtureNestedDelegatedErrors',
-              'level_a.txt',
-                [],
+                'TUFTestFixtureNestedDelegatedErrors',
+                'level_a.txt',
+                [
+                    'root' => 6,
+                    'timestamp' => 6,
+                    'snapshot' => 6,
+                    'targets' => 6,
+                    // The client does not update the 'unclaimed.json' file because
+                    // the target file does not match the 'paths' property for the role.
+                    'unclaimed' => 1,
+                    'level_2' => null,
+                    'level_2_after_terminating' => null,
+                    'level_2_terminating' => null,
+                    'level_3' => null,
+                    'level_3_below_terminated' => null,
+                ],
             ],
             // 'level_1_3_target.txt' is added via the 'level_2' role which has
             // `paths: ['level_1_2_*.txt']`. The 'level_2' role is delegated from the
             // 'unclaimed' role which has `paths: ['level_1_*.txt']`. The file matches
             // for the 'unclaimed' role but does not match for the 'level_2' role.
             'matches parent delegation' => [
-              'TUFTestFixtureNestedDelegatedErrors',
-              'level_1_3_target.txt',
-                [],
+                'TUFTestFixtureNestedDelegatedErrors',
+                'level_1_3_target.txt',
+                [
+                    'root' => 6,
+                    'timestamp' => 6,
+                    'snapshot' => 6,
+                    'targets' => 6,
+                    'unclaimed' => 3,
+                    'level_2' => null,
+                    'level_2_after_terminating' => null,
+                    'level_2_terminating' => null,
+                    'level_3' => null,
+                    'level_3_below_terminated' => null,
+                ],
             ],
             // 'level_2_unfindable.txt' is added via the 'level_2_error' role which has
             // `paths: ['level_2_*.txt']`. The 'level_2_error' role is delegated from the
@@ -370,9 +399,22 @@ class UpdaterTest extends TestCase
             // 'paths' property is incompatible with the its parent delegation's
             // 'paths' property.
             'delegated path does not match parent' => [
-              'TUFTestFixtureNestedDelegatedErrors',
-              'level_2_unfindable.txt',
-              [],
+                'TUFTestFixtureNestedDelegatedErrors',
+                'level_2_unfindable.txt',
+                [
+                    'root' => 6,
+                    'timestamp' => 6,
+                    'snapshot' => 6,
+                    'targets' => 6,
+                    // The client does not update the 'unclaimed.json' file because
+                    // the target file does not match the 'paths' property for the role.
+                    'unclaimed' => 1,
+                    'level_2' => null,
+                    'level_2_after_terminating' => null,
+                    'level_2_terminating' => null,
+                    'level_3' => null,
+                    'level_3_below_terminated' => null,
+                ],
             ],
             // 'level_2_after_terminating_unfindable.txt' is added via role
             // 'level_2_after_terminating' which is delegated from role at the same level as 'level_2_terminating'
@@ -381,9 +423,25 @@ class UpdaterTest extends TestCase
             // delegations are evaluated after it.
             // See § 5.6.7.2.1 and 5.6.7.2.2.
             'delegation is after terminating delegation' => [
-              'TUFTestFixtureNestedDelegatedErrors',
-              'level_2_after_terminating_unfindable.txt',
-              [],
+                'TUFTestFixtureNestedDelegatedErrors',
+                // @todo file file name in https://github.com/php-tuf/php-tuf/pull/216 becauses it does match the
+                // 'paths' property for 'unclaimed' and therefore cannot be find.
+                'level_2_after_terminating_unfindable.txt',
+                [
+                    'root' => 6,
+                    'timestamp' => 6,
+                    'snapshot' => 6,
+                    'targets' => 6,
+                    // The client does not update the 'unclaimed.json' file because
+                    // the target file does not match the 'paths' property for the role.
+                    // @todo Update version in https://github.com/php-tuf/php-tuf/pull/216
+                    'unclaimed' => 1,
+                    'level_2' => null,
+                    'level_2_after_terminating' => null,
+                    'level_2_terminating' => null,
+                    'level_3' => null,
+                    'level_3_below_terminated' => null,
+                ],
             ],
         ];
     }

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -313,20 +313,23 @@ class UpdaterTest extends TestCase
         self::expectExceptionMessage("Target not found: $fileName");
         $updater->download($fileName)->wait();
     }
+
     /**
      * Tests that improperly delegated targets will produce exceptions.
      *
+     * @param string $fixturesSet
      * @param string $fileName
+     * @param array $expectedClientVersions
      *
      * @dataProvider providerDelegationErrors
      */
-    public function testDelegationErrors(string $fileName): void
+    public function testDelegationErrors(string $fixturesSet, string $fileName, array $expectedClientVersions): void
     {
-        $fixturesSet = 'TUFTestFixtureNestedDelegatedErrors';
         $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
         $this->testRepo = new TestRepo($fixturesSet);
         $updater = $this->getSystemInTest();
         $testFilePath = static::getFixturesRealPath($fixturesSet, "server/targets/$fileName", false);
+        self::assertFileExists($testFilePath);
         self::expectException(NotFoundException::class);
         self::expectExceptionMessage("Target not found: $fileName");
         $updater->download($fileName)->wait();
@@ -345,12 +348,20 @@ class UpdaterTest extends TestCase
         return [
             // 'level_a.txt' is added via the 'unclaimed' role but this role has
             // `paths: ['level_1_*.txt']` which does not match the file name.
-            'no path match' => ['level_a.txt'],
+            'no path match' => [
+              'TUFTestFixtureNestedDelegatedErrors',
+              'level_a.txt',
+                [],
+            ],
             // 'level_1_3_target.txt' is added via the 'level_2' role which has
             // `paths: ['level_1_2_*.txt']`. The 'level_2' role is delegated from the
             // 'unclaimed' role which has `paths: ['level_1_*.txt']`. The file matches
             // for the 'unclaimed' role but does not match for the 'level_2' role.
-            'matches parent delegation' => ['level_1_3_target.txt'],
+            'matches parent delegation' => [
+              'TUFTestFixtureNestedDelegatedErrors',
+              'level_1_3_target.txt',
+                [],
+            ],
             // 'level_2_unfindable.txt' is added via the 'level_2_error' role which has
             // `paths: ['level_2_*.txt']`. The 'level_2_error' role is delegated from the
             // 'unclaimed' role which has `paths: ['level_1_*.txt']`. The file matches
@@ -358,14 +369,22 @@ class UpdaterTest extends TestCase
             // No files added via the 'level_2_error' role will be found because its
             // 'paths' property is incompatible with the its parent delegation's
             // 'paths' property.
-            'delegated path does not match parent' => ['level_2_unfindable.txt'],
+            'delegated path does not match parent' => [
+              'TUFTestFixtureNestedDelegatedErrors',
+              'level_2_unfindable.txt',
+              [],
+            ],
             // 'level_2_after_terminating_unfindable.txt' is added via role
             // 'level_2_after_terminating' which is delegated from role at the same level as 'level_2_terminating'
             //  but added after 'level_2_terminating'.
             // Because 'level_2_terminating' is a terminating role its own delegations are evaluated but no other
             // delegations are evaluated after it.
             // See § 5.6.7.2.1 and 5.6.7.2.2.
-            'delegation is after terminating delegation' => ['level_2_after_terminating_unfindable.txt'],
+            'delegation is after terminating delegation' => [
+              'TUFTestFixtureNestedDelegatedErrors',
+              'level_2_after_terminating_unfindable.txt',
+              [],
+            ],
         ];
     }
 


### PR DESCRIPTION
this will make  testing https://github.com/php-tuf/php-tuf/pull/216 easier and more robust

Add extra arguments to testDelegationErrors() 

This allows testing other fixtures.

Also adding `$expectedClientVersions` allows the test to confirm which roles were evaluated without this confirmation we don't know if a file was not found  because the role was not evaluated or evaluated and  file was still not found.