### PR TITLE
\Tuf\Metadata\Factory doesn't account for delegated roles

### DIFF
--- a/src/Metadata/Factory.php
+++ b/src/Metadata/Factory.php
@@ -50,7 +50,7 @@ class Factory
                     $currentMetadata = TimestampMetadata::createFromJson($json);
                     break;
                 default:
-                    $currentMetadata = TargetsMetadata::createFromJson($json);
+                    $currentMetadata = TargetsMetadata::createFromJson($json, $role);
             }
             $currentMetadata->trust();
             return $currentMetadata;

--- a/tests/Metadata/FactoryTest.php
+++ b/tests/Metadata/FactoryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tuf\Tests\Metadata;
+
+use Tuf\Metadata\Factory;
+use PHPUnit\Framework\TestCase;
+use Tuf\Metadata\RootMetadata;
+use Tuf\Metadata\SnapshotMetadata;
+use Tuf\Metadata\TargetsMetadata;
+use Tuf\Metadata\TimestampMetadata;
+use Tuf\Tests\TestHelpers\DurableStorage\MemoryStorageLoaderTrait;
+
+/**
+ * @coversDefaultClass \Tuf\Metadata\Factory
+ */
+class FactoryTest extends TestCase
+{
+    use MemoryStorageLoaderTrait;
+
+    /**
+     * @covers ::load
+     *
+     * @dataProvider providerLoad
+     *
+     * @param string $class
+     *   The class name of the expected metadata.
+     * @param string $role
+     *   The role to load.
+     */
+    public function testLoad(string $class, string $role): void
+    {
+        $localRepo = $this->memoryStorageFromFixture('TUFTestFixtureDelegated', 'client/metadata/current');
+        $factory = new Factory($localRepo);
+
+        $metadata = $factory->load($role);
+        self::assertInstanceOf($class, $metadata);
+        self::assertEquals($class::TYPE, $metadata->getType());
+        self::assertEquals($role, $metadata->getRole());
+    }
+
+    /**
+     * Data provider for testLoad().
+     *
+     * @return array
+     */
+    public function providerLoad(): array
+    {
+        return self::getKeyedArray([
+            [RootMetadata::class, 'root'],
+            [TimestampMetadata::class, 'timestamp'],
+            [SnapshotMetadata::class, 'snapshot'],
+            [TargetsMetadata::class, 'targets'],
+            [TargetsMetadata::class, 'unclaimed'],
+        ]);
+    }
+}

--- a/tests/Metadata/FactoryTest.php
+++ b/tests/Metadata/FactoryTest.php
@@ -34,8 +34,8 @@ class FactoryTest extends TestCase
 
         $metadata = $factory->load($role);
         self::assertInstanceOf($class, $metadata);
-        self::assertEquals($class::TYPE, $metadata->getType());
-        self::assertEquals($role, $metadata->getRole());
+        self::assertSame($class::TYPE, $metadata->getType());
+        self::assertSame($role, $metadata->getRole());
     }
 
     /**


### PR DESCRIPTION
This adds test for the class in 1 commit and fixes the problem in the next

Discovered this in #216 because need to call `\Tuf\Metadata\TargetsMetadata::getRole()` and it was always returning 'targets' even for delegated roles. 