### PR TITLE
Add test_targets.json to each test fixture that has the expected outcome for attempt to download each target

### DIFF
--- a/fixtures/TUFTestFixtureNestedDelegated/test_targets.json
+++ b/fixtures/TUFTestFixtureNestedDelegated/test_targets.json
@@ -1,0 +1,72 @@
+[
+  {
+    "target_path": "level_1_target.txt",
+    "find": true,
+    "expected_versions": {
+      "root": 5,
+      "timestamp": 5,
+      "snapshot": 5,
+      "targets": 5,
+      "unclaimed": 2,
+      "level_2": null,
+      "level_3": null
+    }
+  },
+  {
+    "target_path": "level_1_2_target.txt",
+    "find": true,
+    "expected_versions": {
+      "root": 5,
+      "timestamp": 5,
+      "snapshot": 5,
+      "targets": 5,
+      "unclaimed": 2,
+      "level_2": 1,
+      "level_2_terminating": null,
+      "level_3": null
+    }
+  },
+  {
+      "target_path": "level_1_2_terminating_findable.txt",
+      "find": true,
+      "expected_versions": {
+        "root": 5,
+        "timestamp": 5,
+        "snapshot": 5,
+        "targets": 5,
+        "unclaimed": 2,
+        "level_2": 1,
+        "level_2_terminating": 1,
+        "level_3": null
+      }
+  },
+  {
+    "target_path": "level_1_2_3_below_non_terminating_target.txt",
+    "find": true,
+    "expected_versions": {
+      "root": 5,
+      "timestamp": 5,
+      "snapshot": 5,
+      "targets": 5,
+      "unclaimed": 2,
+      "level_2": 1,
+      "level_2_terminating": null,
+      "level_3": 1
+    }
+  },
+  {
+    "target_path": "level_1_2_terminating_3_target.txt",
+    "find": true,
+    "expected_versions": {
+      "root": 5,
+      "timestamp": 5,
+      "snapshot": 5,
+      "targets": 5,
+      "unclaimed": 2,
+      "level_2": 1,
+      "level_2_terminating": 1,
+      "level_3": null,
+      "level_3_below_terminated": 1
+    }
+  }
+]


### PR DESCRIPTION
Right we have to test providers for downloading targets `providerVerifiedDelegatedDownload()` and `providerDelegationErrors()`. This makes it complicated to all the test cases for 1 fixture. I had [1 idea](url) to simplify but it also may be simpler if the test cases for each fixture where in file with the fixture itself. 

I can see how this would work be test cases for attempt to download targets but haven't thought about it with other tests yet.