### PR TITLE
Remove constants.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
     "autoload": {
         "psr-4": {
             "Tuf\\": "src/"
-        },
-        "files": ["src/constants.php"]
+        }
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/KeyDB.php
+++ b/src/KeyDB.php
@@ -60,16 +60,10 @@ class KeyDB
      *
      * @return string[]
      *     An array of supported encryption key type names (e.g. 'ed25519').
-     *
-     * @see src/constants.php
      */
     public static function getSupportedKeyTypes(): array
     {
-        static $types = [];
-        if (count($types) == 0) {
-            $types = explode(" ", SUPPORTED_KEY_TYPES);
-        }
-        return $types;
+        return ['ed25519'];
     }
 
     /**

--- a/src/constants.php
+++ b/src/constants.php
@@ -1,5 +1,0 @@
-<?php
-/**
- * Space-delimited list of key types supported by php-tuf.
- */
-define('SUPPORTED_KEY_TYPES', 'ed25519');


### PR DESCRIPTION
Do we really need this file? I don't understand the usefulness. So, if everyone agrees, maybe we just remove it for now...