### PR TITLE
Move some overhead into getSystemInTest()

### DIFF
--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -127,6 +127,8 @@ class UpdaterTest extends TestCase
             ],
         ];
 
+        $this->testRepo = new TestRepo($fixturesSet);
+
         // Remove all '*.[TYPE].json' because they are needed for the tests.
         $fixtureFiles = scandir(static::getFixturesRealPath($fixturesSet, 'client/metadata/current'));
         $this->assertNotEmpty($fixtureFiles);
@@ -149,7 +151,6 @@ class UpdaterTest extends TestCase
     {
         $fixturesSet = 'TUFTestFixtureSimple';
         $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
-        $this->testRepo = new TestRepo($fixturesSet);
         $updater = $this->getSystemInTest($fixturesSet);
 
         $testFilePath = static::getFixturesRealPath($fixturesSet, 'server/targets/testtarget.txt', false);
@@ -229,7 +230,6 @@ class UpdaterTest extends TestCase
     public function testVerifiedDelegatedDownload(string $fixturesSet, string $delegatedFile, array $expectedFileVersions): void
     {
         $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
-        $this->testRepo = new TestRepo($fixturesSet);
         $updater = $this->getSystemInTest($fixturesSet);
 
         $testFilePath = static::getFixturesRealPath($fixturesSet, "server/targets/$delegatedFile", false);
@@ -589,7 +589,6 @@ class UpdaterTest extends TestCase
 
         // Ensure the file can found if the maximum role limit is 100.
         $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
-        $this->testRepo = new TestRepo($fixturesSet);
         $updater = $this->getSystemInTest($fixturesSet);
         $testFilePath = static::getFixturesRealPath($fixturesSet, "server/targets/$fileName", false);
         $testFileContents = file_get_contents($testFilePath);
@@ -599,7 +598,6 @@ class UpdaterTest extends TestCase
 
         // Ensure the file can not found if the maximum role limit is 3.
         $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
-        $this->testRepo = new TestRepo($fixturesSet);
         $updater = $this->getSystemInTest($fixturesSet, LimitRolesTestUpdater::class);
         self::expectException(NotFoundException::class);
         self::expectExceptionMessage("Target not found: $fileName");
@@ -623,7 +621,6 @@ class UpdaterTest extends TestCase
     public function testDelegationErrors(string $fixturesSet, string $fileName, array $expectedFileVersions): void
     {
         $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
-        $this->testRepo = new TestRepo($fixturesSet);
         $updater = $this->getSystemInTest($fixturesSet);
         try {
             $updater->download($fileName)->wait();
@@ -887,7 +884,6 @@ class UpdaterTest extends TestCase
         // Use the memory storage used so tests can write without permanent
         // side-effects.
         $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
-        $this->testRepo = new TestRepo($fixturesSet);
 
         $this->assertClientFileVersions($expectedStartVersion);
         $updater = $this->getSystemInTest($fixturesSet);
@@ -901,7 +897,6 @@ class UpdaterTest extends TestCase
 
         // Create another version of the client that only starts with the root.json file.
         $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
-        $this->testRepo = new TestRepo($fixturesSet);
         foreach (array_keys($expectedStartVersion) as $role) {
             if ($role !== 'root') {
                 // Change the expectation that client will not start with any files other than root.json.
@@ -1035,10 +1030,9 @@ class UpdaterTest extends TestCase
         // side-effects.
         $fixturesSet = 'TUFTestFixtureDelegated';
         $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
-        $this->testRepo = new TestRepo($fixturesSet);
         $this->assertClientFileVersions(static::getFixtureClientStartVersions('TUFTestFixtureDelegated'));
-        $this->testRepo->setRepoFileNestedValue($fileToChange, $keys, $newValue);
         $updater = $this->getSystemInTest($fixturesSet);
+        $this->testRepo->setRepoFileNestedValue($fileToChange, $keys, $newValue);
         try {
             $updater->refresh();
         } catch (TufException $exception) {
@@ -1183,10 +1177,9 @@ class UpdaterTest extends TestCase
         // Use the memory storage used so tests can write without permanent
         // side-effects.
         $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
-        $this->testRepo = new TestRepo($fixturesSet);
         $this->assertClientFileVersions(static::getFixtureClientStartVersions($fixturesSet));
-        $this->testRepo->removeRepoFile($fileName);
         $updater = $this->getSystemInTest($fixturesSet);
+        $this->testRepo->removeRepoFile($fileName);
         try {
             $updater->refresh();
         } catch (RepoFileNotFound $exception) {
@@ -1302,7 +1295,6 @@ class UpdaterTest extends TestCase
     public function testSignatureThresholds(string $fixturesSet, string $expectedException = null)
     {
         $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
-        $this->testRepo = new TestRepo($fixturesSet);
         $updater = $this->getSystemInTest($fixturesSet);
         $this->assertClientFileVersions(static::getFixtureClientStartVersions($fixturesSet));
         if ($expectedException) {
@@ -1318,7 +1310,6 @@ class UpdaterTest extends TestCase
     {
         $fixturesSet = 'TUFTestFixtureSimple';
         $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
-        $this->testRepo = new TestRepo($fixturesSet);
 
         $this->assertClientFileVersions(static::getFixtureClientStartVersions($fixturesSet));
         $updater = $this->getSystemInTest($fixturesSet);
@@ -1346,7 +1337,6 @@ class UpdaterTest extends TestCase
     {
         $fixtureSet = 'TUFTestFixtureUnsupportedDelegation';
         $this->localRepo = $this->memoryStorageFromFixture($fixtureSet, 'client/metadata/current');
-        $this->testRepo = new TestRepo($fixtureSet);
         $startingTargets = $this->localRepo['targets.json'];
         $this->assertClientFileVersions(static::getFixtureClientStartVersions($fixtureSet));
         $updater = $this->getSystemInTest($fixtureSet);
@@ -1394,7 +1384,6 @@ class UpdaterTest extends TestCase
         // Use the memory storage used so tests can write without permanent
         // side-effects.
         $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
-        $this->testRepo = new TestRepo($fixturesSet);
         $this->assertClientFileVersions(static::getFixtureClientStartVersions($fixturesSet));
         $updater = $this->getSystemInTest($fixturesSet);
         try {

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -127,6 +127,7 @@ class UpdaterTest extends TestCase
             ],
         ];
 
+        $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
         $this->testRepo = new TestRepo($fixturesSet);
 
         // Remove all '*.[TYPE].json' because they are needed for the tests.
@@ -150,7 +151,6 @@ class UpdaterTest extends TestCase
     public function testVerifiedDownload(): void
     {
         $fixturesSet = 'TUFTestFixtureSimple';
-        $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
         $updater = $this->getSystemInTest($fixturesSet);
 
         $testFilePath = static::getFixturesRealPath($fixturesSet, 'server/targets/testtarget.txt', false);
@@ -229,7 +229,6 @@ class UpdaterTest extends TestCase
      */
     public function testVerifiedDelegatedDownload(string $fixturesSet, string $delegatedFile, array $expectedFileVersions): void
     {
-        $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
         $updater = $this->getSystemInTest($fixturesSet);
 
         $testFilePath = static::getFixturesRealPath($fixturesSet, "server/targets/$delegatedFile", false);
@@ -588,7 +587,6 @@ class UpdaterTest extends TestCase
         $fileName = 'level_1_2_terminating_3_target.txt';
 
         // Ensure the file can found if the maximum role limit is 100.
-        $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
         $updater = $this->getSystemInTest($fixturesSet);
         $testFilePath = static::getFixturesRealPath($fixturesSet, "server/targets/$fileName", false);
         $testFileContents = file_get_contents($testFilePath);
@@ -597,7 +595,6 @@ class UpdaterTest extends TestCase
 
 
         // Ensure the file can not found if the maximum role limit is 3.
-        $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
         $updater = $this->getSystemInTest($fixturesSet, LimitRolesTestUpdater::class);
         self::expectException(NotFoundException::class);
         self::expectExceptionMessage("Target not found: $fileName");
@@ -620,7 +617,6 @@ class UpdaterTest extends TestCase
      */
     public function testDelegationErrors(string $fixturesSet, string $fileName, array $expectedFileVersions): void
     {
-        $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
         $updater = $this->getSystemInTest($fixturesSet);
         try {
             $updater->download($fileName)->wait();
@@ -883,10 +879,9 @@ class UpdaterTest extends TestCase
         $expectedStartVersion = static::getFixtureClientStartVersions($fixturesSet);
         // Use the memory storage used so tests can write without permanent
         // side-effects.
-        $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
 
-        $this->assertClientFileVersions($expectedStartVersion);
         $updater = $this->getSystemInTest($fixturesSet);
+        $this->assertClientFileVersions($expectedStartVersion);
         $this->assertTrue($updater->refresh($fixturesSet));
         // Confirm the local version are updated to the expected versions.
         // § 5.3.8
@@ -896,7 +891,7 @@ class UpdaterTest extends TestCase
         $this->assertClientFileVersions($expectedUpdatedVersions);
 
         // Create another version of the client that only starts with the root.json file.
-        $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
+        $updater = $this->getSystemInTest($fixturesSet);
         foreach (array_keys($expectedStartVersion) as $role) {
             if ($role !== 'root') {
                 // Change the expectation that client will not start with any files other than root.json.
@@ -906,7 +901,6 @@ class UpdaterTest extends TestCase
             }
         }
         $this->assertClientFileVersions($expectedStartVersion);
-        $updater = $this->getSystemInTest($fixturesSet);
         $this->assertTrue($updater->refresh());
         // Confirm that if we start with only root.json all of the files still
         // update to the expected versions.
@@ -1029,9 +1023,8 @@ class UpdaterTest extends TestCase
         // Use the memory storage used so tests can write without permanent
         // side-effects.
         $fixturesSet = 'TUFTestFixtureDelegated';
-        $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
-        $this->assertClientFileVersions(static::getFixtureClientStartVersions('TUFTestFixtureDelegated'));
         $updater = $this->getSystemInTest($fixturesSet);
+        $this->assertClientFileVersions(static::getFixtureClientStartVersions('TUFTestFixtureDelegated'));
         $this->testRepo->setRepoFileNestedValue($fileToChange, $keys, $newValue);
         try {
             $updater->refresh();
@@ -1176,9 +1169,8 @@ class UpdaterTest extends TestCase
     {
         // Use the memory storage used so tests can write without permanent
         // side-effects.
-        $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
-        $this->assertClientFileVersions(static::getFixtureClientStartVersions($fixturesSet));
         $updater = $this->getSystemInTest($fixturesSet);
+        $this->assertClientFileVersions(static::getFixtureClientStartVersions($fixturesSet));
         $this->testRepo->removeRepoFile($fileName);
         try {
             $updater->refresh();
@@ -1294,7 +1286,6 @@ class UpdaterTest extends TestCase
      */
     public function testSignatureThresholds(string $fixturesSet, string $expectedException = null)
     {
-        $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
         $updater = $this->getSystemInTest($fixturesSet);
         $this->assertClientFileVersions(static::getFixtureClientStartVersions($fixturesSet));
         if ($expectedException) {
@@ -1309,10 +1300,9 @@ class UpdaterTest extends TestCase
     public function testUpdateRefresh(): void
     {
         $fixturesSet = 'TUFTestFixtureSimple';
-        $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
 
-        $this->assertClientFileVersions(static::getFixtureClientStartVersions($fixturesSet));
         $updater = $this->getSystemInTest($fixturesSet);
+        $this->assertClientFileVersions(static::getFixtureClientStartVersions($fixturesSet));
         // This refresh should succeed.
         $updater->refresh();
         // Put the server-side repo into an invalid state.
@@ -1336,10 +1326,9 @@ class UpdaterTest extends TestCase
     public function testUnsupportedRepo(): void
     {
         $fixtureSet = 'TUFTestFixtureUnsupportedDelegation';
-        $this->localRepo = $this->memoryStorageFromFixture($fixtureSet, 'client/metadata/current');
+        $updater = $this->getSystemInTest($fixtureSet);
         $startingTargets = $this->localRepo['targets.json'];
         $this->assertClientFileVersions(static::getFixtureClientStartVersions($fixtureSet));
-        $updater = $this->getSystemInTest($fixtureSet);
         try {
             $updater->refresh();
         } catch (MetadataException $exception) {
@@ -1383,9 +1372,8 @@ class UpdaterTest extends TestCase
     {
         // Use the memory storage used so tests can write without permanent
         // side-effects.
-        $this->localRepo = $this->memoryStorageFromFixture($fixturesSet, 'client/metadata/current');
-        $this->assertClientFileVersions(static::getFixtureClientStartVersions($fixturesSet));
         $updater = $this->getSystemInTest($fixturesSet);
+        $this->assertClientFileVersions(static::getFixtureClientStartVersions($fixturesSet));
         try {
             // No changes should be made to client repo.
             $this->localRepo->setExceptionOnChange();

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -137,10 +137,15 @@ class UpdaterTest extends TestCase
     }
 
     /**
-     * Returns a memory-based updater populated with the test fixtures.
+     * Returns a memory-based updater populated with a specific test fixture.
+     *
+     * This will initialize $this->testRepo to fetch server-side metadata from
+     * the fixture, and $this->localRepo to interact with the fixture's
+     * client-side metadata. Both are kept in memory only, and will not cause
+     * any permanent side effects.
      *
      * @param string $fixturesSet
-     *     The fixtures set to use.
+     *     The name of the fixture to use.
      *
      * @return Updater
      *     The test updater, which uses the 'current' test fixtures in the


### PR DESCRIPTION
This PR does three interrelated things:

1. It makes `getSystemInTest()` set up `$this->testRepo`.
2. And `$this->localRepo`.
3. It makes `getSystemInTest()` always assert the hard-coded starting versions, for extra safety and consistency.