### PR TITLE
Make fields > delegations optional according to specifications

### DIFF
--- a/src/Metadata/TargetsMetadata.php
+++ b/src/Metadata/TargetsMetadata.php
@@ -48,7 +48,7 @@ class TargetsMetadata extends MetadataBase
     protected static function getSignedCollectionOptions(): array
     {
         $options = parent::getSignedCollectionOptions();
-        $options['fields']['delegations'] = new Required([
+        $options['fields']['delegations'] = new Optional([
             new Collection([
                 'keys' => new Required([
                     new Type('\ArrayObject'),


### PR DESCRIPTION
According to the TUF specifications, the fields > delegations field on the targets file should be optional (https://theupdateframework.github.io/specification/latest/#file-formats-targets). This can be accomplished by changing the getSignedCollectionOptions method and making $options['fields']['delegations'] an Optional instead of Required