### PR TITLE
Allow spec version "1.0" for compatibility with older TUF implementations

### DIFF
--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -3,10 +3,12 @@
 namespace Tuf\Metadata;
 
 use Symfony\Component\Validator\Constraints\All;
+use Symfony\Component\Validator\Constraints\AtLeastOneOf;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\Count;
 use Symfony\Component\Validator\Constraints\DateTime;
 use Symfony\Component\Validator\Constraints\EqualTo;
+use Symfony\Component\Validator\Constraints\IdenticalTo;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Component\Validator\Constraints\Required;
@@ -157,7 +159,10 @@ abstract class MetadataBase
                 'spec_version' => [
                     new NotBlank(),
                     new Type('string'),
-                    new Regex('/^1\.[0-9]+\.[0-9]+$/'),
+                    new AtLeastOneOf([
+                      new IdenticalTo('1.0'),
+                      new Regex('/^1\.[0-9]+\.[0-9]+$/'),
+                    ]),
                 ],
             ] + static::getVersionConstraints(),
             'allowExtraFields' => true,

--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -160,8 +160,8 @@ abstract class MetadataBase
                     new NotBlank(),
                     new Type('string'),
                     new AtLeastOneOf([
-                      new IdenticalTo('1.0'),
-                      new Regex('/^1\.[0-9]+\.[0-9]+$/'),
+                        new IdenticalTo('1.0'),
+                        new Regex('/^1\.[0-9]+\.[0-9]+$/'),
                     ]),
                 ],
             ] + static::getVersionConstraints(),

--- a/tests/Metadata/MetaDataBaseTest.php
+++ b/tests/Metadata/MetaDataBaseTest.php
@@ -153,7 +153,15 @@ abstract class MetadataBaseTest extends TestCase
      * @param boolean $valid
      *   Whether it's valid.
      *
-     * @dataProvider providerSpecVersion
+     * @testWith ["1", false]
+     *   ["1.0", true]
+     *   ["1.1", false]
+     *   ["1.99", false]
+     *   ["2.00", false]
+     *   ["1.0.a", false]
+     *   ["1.0.1", true]
+     *   ["1.99.8", true]
+     *   ["1.1.1", true]
      */
     public function testSpecVersion(string $version, bool $valid): void
     {
@@ -326,25 +334,6 @@ abstract class MetadataBaseTest extends TestCase
             ['2030-11-01T20:50:10Z', true],
             ['2330-12-21T20:50:10Z', true],
         ]);
-    }
-
-    /**
-     * Dataprovider for testSpecVersion().
-     *
-     * @return array
-     *   Array of arrays of spec version, and whether it should be valid.
-     */
-    public function providerSpecVersion(): array
-    {
-        return [
-            ['1', false],
-            ['1.0', false],
-            ['2.00', false],
-            ['1.0.a', false],
-            ['1.0.1', true],
-            ['1.99.8', true],
-            ['1.1.1', true],
-        ];
     }
 
     /**


### PR DESCRIPTION
Based on the specification the spec_version has to be x.y.z sadly some implementations generates x.y entries.

More information can be found in https://github.com/theupdateframework/go-tuf/issues/206#issuecomment-1020213003