### PR TITLE
Make guzzlehttp client a composer suggestion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,13 @@
         "ext-json": "*",
         "paragonie/sodium_compat": "^1.13",
         "symfony/validator": "^4.4 || ^5",
-        "guzzlehttp/guzzle": "^6.5 || ^7.2",
         "myclabs/deep-copy": "^1.10.2",
-        "guzzlehttp/psr7": "^1.7"
+        "guzzlehttp/psr7": "^1.7",
+        "guzzlehttp/promises": "^1.5"
     },
     "suggest": {
-        "ext-libsodium": "Provides faster verification of updates"
+        "ext-libsodium": "Provides faster verification of updates",
+        "guzzlehttp/guzzle": "Required package if GuzzleFileFetcher shall be used"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The current TUF client implementation has a hardcoded dependency for the guzzlehttp client even though the FileFetcherInterface defines a generic (guzzle) promise as a return type and therefore isn't bound to guzzle as http client. This PR makes the http client a suggestion, allowing downstream projects to either use Guzzle/Http or their own implementation of a file fetcher without having the hardcoded dependency wired into this package.