### PR TITLE
Drop support for PHP 7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.2'
+          php-version: '8.0'
           tools: composer:v2
 
       - name: Setup problem matchers for PHP

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
       max-parallel: 10
       matrix:
         operating-system: [ubuntu-latest, macos-latest, windows-latest]
-        php: ['7.4', '7.3', '7.2']
+        php: ['8.0', '8.1', '8.2']
         dependencies:
           - 'symfony/validator:^4.4'
           - 'symfony/validator:^5'

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Composer project. Contributing projects:
 The PHP-TUF client is designed to provide TUF verification to PHP applications
 for target signatures.
 
-- Minimum required PHP version: 7.2
+- Minimum required PHP version: 8.0
 - Requires `ext-json`
 - The `paragonie/sodium_compat` dependency provides a polyfill for the Sodium
   cryptography library; however, installing `ext-sodium` is recommended for

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
         "phpunit/phpunit": "^9",
         "symfony/phpunit-bridge": "^5",
         "squizlabs/php_codesniffer": "^3.7",
-        "slevomat/coding-standard": "^8.2"
+        "slevomat/coding-standard": "^8.2",
+        "phpspec/prophecy-phpunit": "^2"
     },
     "license": "MIT",
     "minimum-stability": "dev",
@@ -18,8 +19,7 @@
         "symfony/validator": "^4.4 || ^5",
         "guzzlehttp/guzzle": "^6.5 || ^7.2",
         "myclabs/deep-copy": "^1.10.2",
-        "guzzlehttp/psr7": "^1.7",
-        "phpspec/prophecy-phpunit": "^2"
+        "guzzlehttp/psr7": "^1.7"
     },
     "suggest": {
         "ext-sodium": "Provides faster verification of updates"

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PHP implementation of The Update Framework (TUF)",
     "type": "library",
     "require-dev": {
-        "phpunit/phpunit": "^8.5.8|^9",
+        "phpunit/phpunit": "^9",
         "symfony/phpunit-bridge": "^5",
         "squizlabs/php_codesniffer": "^3.7",
         "slevomat/coding-standard": "^8.2"
@@ -12,7 +12,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=7.2.5",
+        "php": "^8",
         "ext-json": "*",
         "paragonie/sodium_compat": "^1.13",
         "symfony/validator": "^4.4 || ^5",
@@ -21,7 +21,7 @@
         "guzzlehttp/psr7": "^1.7"
     },
     "suggest": {
-        "ext-libsodium": "Provides faster verification of updates"
+        "ext-sodium": "Provides faster verification of updates"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "symfony/validator": "^4.4 || ^5",
         "guzzlehttp/guzzle": "^6.5 || ^7.2",
         "myclabs/deep-copy": "^1.10.2",
-        "guzzlehttp/psr7": "^1.7"
+        "guzzlehttp/psr7": "^1.7",
+        "phpspec/prophecy-phpunit": "^2"
     },
     "suggest": {
         "ext-sodium": "Provides faster verification of updates"

--- a/src/Client/DurableStorage/DurableStorageAccessValidator.php
+++ b/src/Client/DurableStorage/DurableStorageAccessValidator.php
@@ -55,7 +55,7 @@ class DurableStorageAccessValidator implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         $this->throwIfInvalidOffset($offset);
         return $this->backend->offsetExists($offset);
@@ -64,7 +64,7 @@ class DurableStorageAccessValidator implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         $this->throwIfInvalidOffset($offset);
         return $this->backend->offsetGet($offset);
@@ -73,7 +73,7 @@ class DurableStorageAccessValidator implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->throwIfInvalidOffset($offset);
         // @todo Consider enforcing an application-configurable maximum length
@@ -88,7 +88,7 @@ class DurableStorageAccessValidator implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->throwIfInvalidOffset($offset);
         $this->backend->offsetUnset($offset);

--- a/src/Client/DurableStorage/FileStorage.php
+++ b/src/Client/DurableStorage/FileStorage.php
@@ -51,7 +51,7 @@ class FileStorage implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return file_exists($this->pathWithBasePath($offset));
     }
@@ -59,7 +59,7 @@ class FileStorage implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return file_get_contents($this->pathWithBasePath($offset));
     }
@@ -67,7 +67,7 @@ class FileStorage implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         file_put_contents($this->pathWithBasePath($offset), $value);
     }
@@ -75,7 +75,7 @@ class FileStorage implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         @unlink($this->pathWithBasePath($offset));
     }

--- a/src/KeyDB.php
+++ b/src/KeyDB.php
@@ -91,7 +91,7 @@ class KeyDB
         if (! in_array($key->getType(), self::getSupportedKeyTypes(), true)) {
             // @todo Convert this to a log line as per Python.
             // https://github.com/php-tuf/php-tuf/issues/160
-            throw new InvalidKeyException("Root metadata file contains an unsupported key type: \"${keyMeta['keytype']}\"");
+            throw new InvalidKeyException("Root metadata file contains an unsupported key type: \"{$keyMeta['keytype']}\"");
         }
         // Per TUF specification 4.3, Clients MUST calculate each KEYID to
         // verify this is correct for the associated key.

--- a/src/Metadata/Verifier/FileInfoVerifier.php
+++ b/src/Metadata/Verifier/FileInfoVerifier.php
@@ -38,8 +38,8 @@ abstract class FileInfoVerifier extends VerifierBase
             /** @var \Tuf\Metadata\SnapshotMetadata|\Tuf\Metadata\TimestampMetadata $untrustedMetadata */
             if ($remoteFileInfo = $untrustedMetadata->getFileMetaInfo($fileName, true)) {
                 if ($remoteFileInfo['version'] < $localFileInfo['version']) {
-                    $message = "Remote $type metadata file '$fileName' version \"${$remoteFileInfo['version']}\" " .
-                      "is less than previously seen  version \"${$localFileInfo['version']}\"";
+                    $message = "Remote $type metadata file '$fileName' version \"{$remoteFileInfo['version']}\" " .
+                      "is less than previously seen  version \"{$localFileInfo['version']}\"";
                     throw new RollbackAttackException($message);
                 }
             }

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Tuf\Client\Updater;
 use Tuf\Exception\DownloadSizeException;
 use Tuf\Exception\MetadataException;
@@ -25,6 +26,7 @@ use Tuf\Tests\TestHelpers\UtilsTrait;
 class UpdaterTest extends TestCase
 {
     use FixturesTrait;
+    use ProphecyTrait;
     use UtilsTrait;
 
     /**

--- a/tests/TestHelpers/DurableStorage/MemoryStorage.php
+++ b/tests/TestHelpers/DurableStorage/MemoryStorage.php
@@ -40,7 +40,7 @@ class MemoryStorage implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if ($this->exceptionOnChange) {
             throw new \LogicException("Unexpected attempt to change client storage.");
@@ -55,7 +55,7 @@ class MemoryStorage implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -63,7 +63,7 @@ class MemoryStorage implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         if ($this->exceptionOnChange) {
             throw new \LogicException("Unexpected attempt to change client storage.");
@@ -74,7 +74,7 @@ class MemoryStorage implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }

--- a/tests/Unit/FileStorageTest.php
+++ b/tests/Unit/FileStorageTest.php
@@ -46,6 +46,6 @@ class FileStorageTest extends TestCase
         $this->assertTrue(isset($storage[$filename]));
         $this->assertSame("From hell's heart, I refactor thee!", $storage[$filename]);
         unset($storage[$filename]);
-        $this->assertFileNotExists("$dir/$filename");
+        $this->assertFileDoesNotExist("$dir/$filename");
     }
 }

--- a/tests/Unit/GuzzleFileFetcherTest.php
+++ b/tests/Unit/GuzzleFileFetcherTest.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Tuf\Client\GuzzleFileFetcher;
 use Tuf\Exception\RepoFileNotFound;
 
@@ -19,6 +20,8 @@ use Tuf\Exception\RepoFileNotFound;
  */
 class GuzzleFileFetcherTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * The mocked request handler.
      *


### PR DESCRIPTION
I propose we drop support for PHP 7, for the following reasons:

* It is EOL. Since this is a security-related, cryptographically-sensitive project, it is a security risk for us to support dead versions of PHP.
* If someone uses PHP-TUF with `ext-sodium` installed, we don't want to inadvertently be using an unsupported, potentially insecure version of the Sodium library built into PHP.
* From the Drupal perspective, we don't really need to require PHP-TUF for _attended_ updates. Therefore, people could still use the Automatic Updates module with PHP 7.4; they'd just need to do their updates in the UI.
* Our tests use Prophecy, which requires PHP 7.3 or later. Additionally, we're currently supporting two major versions of PHPUnit, which leads to awkwardness around deprecated assertions. (This means we either need to drop PHP 7.2 support only, or alter our tests to use PHPUnit mocks instead of Prophecy. Until we do, our CI jobs won't pass.)