### PR TITLE
Support Symfony 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
         dependencies:
           - 'symfony/validator:~4.4'
           - 'symfony/validator:~5.0'
+          - 'symfony/validator:~6.0'
         experimental: [false]
         include:
           - operating-system: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^8",
         "ext-json": "*",
         "paragonie/sodium_compat": "^1.13",
-        "symfony/validator": "^4.4 || ^5",
+        "symfony/validator": "^4.4 || ^5 || ^6",
         "myclabs/deep-copy": "^1.10.2",
         "guzzlehttp/promises": "^1.5",
         "psr/http-message": "^1"


### PR DESCRIPTION
Symfony 6 is the actively supported version of Symfony, and it's also what Drupal 10 requires.

We need to support it, and ensure we're testing with it.