### PR TITLE
Compress generated fixtures to speed up builds and prevent upload/download failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,7 +165,10 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: fixtures
-          path: fixtures
+          path: fixtures.tar.gz
+
+      - name: Extract fixtures
+        run: tar -x -z -f fixtures.tar.gz
 
       - name: Run test suite
         run: composer test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,10 +126,9 @@ jobs:
         run: composer phpcs
 
       - name: Download fixtures
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: fixtures
-          path: fixtures.tar.gz
 
       - name: Extract fixtures
         run: tar -x -z -f fixtures.tar.gz
@@ -162,10 +161,9 @@ jobs:
         run: 'composer update ${{ env.COMPOSER_FLAGS }} --prefer-lowest'
 
       - name: Download fixtures
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: fixtures
-          path: fixtures.tar.gz
 
       - name: Extract fixtures
         run: tar -x -z -f fixtures.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,13 +55,14 @@ jobs:
             git status
             exit 1
         else
+            tar -c -z -f fixtures.tar.gz fixtures
             exit 0
         fi
     - name: Store fixtures as artifact
       uses: actions/upload-artifact@v2
       with:
         name: fixtures
-        path: fixtures/
+        path: fixtures.tar.gz
         retention-days: 5
 
   build:
@@ -128,7 +129,10 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: fixtures
-          path: fixtures
+          path: fixtures.tar.gz
+
+      - name: Extract fixtures
+        run: tar -x -z -f fixtures.tar.gz
 
       - name: Run test suite
         run: composer test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
             exit 0
         fi
     - name: Store fixtures as artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: fixtures
         path: fixtures.tar.gz


### PR DESCRIPTION
I've been seeing some distressing behaviors happening during our CI runs -- uploads and downloads of the generated fixtures will sometimes hang, which requires me to go in and manually cancel and re-run the jobs.

I suspect this may be happening because, according to https://github.com/marketplace/actions/upload-a-build-artifact#too-many-uploads-resulting-in-429-responses, the fixtures are being uploaded as a directory, rather than an archive. With over 1,000 files in the fixtures, it's no wonder that this is causing trouble.

To solve this, I propose that the fixtures be packaged as an archive and uploaded/downloaded that way.