### PR TITLE
Run CI workflow every day

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+    # Run this workflow at 3 AM UTC every day.
+    - cron: '0 3 * * *'
 
 env:
   COMPOSER_FLAGS: "--ansi --no-interaction --no-progress --prefer-dist --optimize-autoloader"


### PR DESCRIPTION
We should be running our tests every day automatically. Not really controversial. This adds syntax to do that at 3 AM UTC, according to the documentation at https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule.