### PR TITLE
Remove unnecessary dependency installation from CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,12 +114,7 @@ jobs:
         run: 'composer require --no-update ${{ matrix.dependencies }}'
 
       - name: Install dependencies
-        if: matrix.php != '8.0'
         run: 'composer install ${{ env.COMPOSER_FLAGS }}'
-
-      - name: Install dependencies (ignore-platform-req)
-        if: matrix.php == '8.0'
-        run: 'composer install ${{ env.COMPOSER_FLAGS }} --ignore-platform-req=php'
 
       - name: PHP linting
         if: matrix.operating-system != 'windows-latest'


### PR DESCRIPTION
We have a bit of our GitHub workflow which installs dependencies, ignoring platform requirements if we're testing against PHP 8.

This only ever existed to get around the fact that, previously, we had a requirement on PHP 7, but wanted to test on PHP 8 anyway. Since we have dropped PHP 7 support, we don't need this shim.