### PR TITLE
Encode both pre- and post-update versions in fixture-specific files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: sodium, json, yaml
+          extensions: sodium, json
           tools: composer:v2
 
       - name: Setup problem matchers for PHP

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: sodium, json
+          extensions: sodium, json, yaml
           tools: composer:v2
 
       - name: Setup problem matchers for PHP

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "slevomat/coding-standard": "^8.2",
         "phpspec/prophecy-phpunit": "^2",
         "guzzlehttp/guzzle": "^6.5 || ^7.2",
-        "guzzlehttp/psr7": "^1.7"
+        "guzzlehttp/psr7": "^1.7",
+        "ext-yaml": "*"
     },
     "license": "MIT",
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "phpspec/prophecy-phpunit": "^2",
         "guzzlehttp/guzzle": "^6.5 || ^7.2",
         "guzzlehttp/psr7": "^1.7",
-        "ext-yaml": "*"
+        "symfony/yaml": "^6"
     },
     "license": "MIT",
     "minimum-stability": "dev",

--- a/fixtures/AttackRollback/consistent/client_versions.ini
+++ b/fixtures/AttackRollback/consistent/client_versions.ini
@@ -1,4 +1,0 @@
-root = 2
-timestamp = 2
-snapshot = 2
-targets = 2

--- a/fixtures/AttackRollback/consistent/versions.yml
+++ b/fixtures/AttackRollback/consistent/versions.yml
@@ -3,3 +3,8 @@ start:
   timestamp: 2
   snapshot: 2
   targets: 2
+updated:
+  root: 2
+  timestamp: 2
+  snapshot: 2
+  targets: 2

--- a/fixtures/AttackRollback/consistent/versions.yml
+++ b/fixtures/AttackRollback/consistent/versions.yml
@@ -1,0 +1,5 @@
+start:
+  root: 2
+  timestamp: 2
+  snapshot: 2
+  targets: 2

--- a/fixtures/Delegated/consistent/client_versions.ini
+++ b/fixtures/Delegated/consistent/client_versions.ini
@@ -1,5 +1,0 @@
-root = 2
-timestamp = 2
-snapshot = 2
-targets = 2
-unclaimed = 1

--- a/fixtures/Delegated/consistent/versions.yml
+++ b/fixtures/Delegated/consistent/versions.yml
@@ -4,3 +4,9 @@ start:
   snapshot: 2
   targets: 2
   unclaimed: 1
+updated:
+  root: 4
+  timestamp: 4
+  snapshot: 4
+  targets: 4
+  unclaimed: 1

--- a/fixtures/Delegated/consistent/versions.yml
+++ b/fixtures/Delegated/consistent/versions.yml
@@ -1,0 +1,6 @@
+start:
+  root: 2
+  timestamp: 2
+  snapshot: 2
+  targets: 2
+  unclaimed: 1

--- a/fixtures/NestedDelegated/consistent/client_versions.ini
+++ b/fixtures/NestedDelegated/consistent/client_versions.ini
@@ -1,7 +1,0 @@
-root = 2
-timestamp = 2
-snapshot = 2
-targets = 2
-unclaimed = 1
-level_2 = null
-level_3 = null

--- a/fixtures/NestedDelegated/consistent/versions.yml
+++ b/fixtures/NestedDelegated/consistent/versions.yml
@@ -6,3 +6,11 @@ start:
   unclaimed: 1
   level_2: null
   level_3: null
+updated:
+  root: 5
+  timestamp: 5
+  snapshot: 5
+  targets: 5
+  unclaimed: 1
+  level_2: null
+  level_3: null

--- a/fixtures/NestedDelegated/consistent/versions.yml
+++ b/fixtures/NestedDelegated/consistent/versions.yml
@@ -1,0 +1,8 @@
+start:
+  root: 2
+  timestamp: 2
+  snapshot: 2
+  targets: 2
+  unclaimed: 1
+  level_2: null
+  level_3: null

--- a/fixtures/NestedDelegatedErrors/consistent/client_versions.ini
+++ b/fixtures/NestedDelegatedErrors/consistent/client_versions.ini
@@ -1,5 +1,0 @@
-root = 2
-timestamp = 2
-snapshot = 2
-targets = 2
-unclaimed = 1

--- a/fixtures/NestedDelegatedErrors/consistent/versions.yml
+++ b/fixtures/NestedDelegatedErrors/consistent/versions.yml
@@ -1,0 +1,6 @@
+start:
+  root: 2
+  timestamp: 2
+  snapshot: 2
+  targets: 2
+  unclaimed: 1

--- a/fixtures/NestedTerminatingNonDelegatingDelegation/consistent/client_versions.ini
+++ b/fixtures/NestedTerminatingNonDelegatingDelegation/consistent/client_versions.ini
@@ -1,4 +1,0 @@
-root = 1
-timestamp = 1
-snapshot = 1
-targets = 1

--- a/fixtures/NestedTerminatingNonDelegatingDelegation/consistent/versions.yml
+++ b/fixtures/NestedTerminatingNonDelegatingDelegation/consistent/versions.yml
@@ -1,0 +1,5 @@
+start:
+  root: 1
+  timestamp: 1
+  snapshot: 1
+  targets: 1

--- a/fixtures/PublishedTwice/consistent/client_versions.ini
+++ b/fixtures/PublishedTwice/consistent/client_versions.ini
@@ -1,4 +1,0 @@
-root = 1
-timestamp = 1
-snapshot = 1
-targets = 1

--- a/fixtures/PublishedTwice/consistent/versions.yml
+++ b/fixtures/PublishedTwice/consistent/versions.yml
@@ -1,0 +1,5 @@
+start:
+  root: 1
+  timestamp: 1
+  snapshot: 1
+  targets: 1

--- a/fixtures/PublishedTwice/consistent/versions.yml
+++ b/fixtures/PublishedTwice/consistent/versions.yml
@@ -3,3 +3,8 @@ start:
   timestamp: 1
   snapshot: 1
   targets: 1
+updated:
+  root: 2
+  timestamp: 1
+  snapshot: 1
+  targets: 1

--- a/fixtures/PublishedTwiceWithRotatedKeys_snapshot/consistent/client_versions.ini
+++ b/fixtures/PublishedTwiceWithRotatedKeys_snapshot/consistent/client_versions.ini
@@ -1,4 +1,0 @@
-root = 1
-timestamp = 1
-snapshot = 1
-targets = 1

--- a/fixtures/PublishedTwiceWithRotatedKeys_snapshot/consistent/versions.yml
+++ b/fixtures/PublishedTwiceWithRotatedKeys_snapshot/consistent/versions.yml
@@ -3,3 +3,10 @@ start:
   timestamp: 1
   snapshot: 1
   targets: 1
+updated:
+  root: 2
+  # We expect the timestamp and snapshot metadata to be deleted from the client if the
+  # snapshot role's keys have been rotated.
+  timestamp: null
+  snapshot: null
+  targets: 1

--- a/fixtures/PublishedTwiceWithRotatedKeys_snapshot/consistent/versions.yml
+++ b/fixtures/PublishedTwiceWithRotatedKeys_snapshot/consistent/versions.yml
@@ -1,0 +1,5 @@
+start:
+  root: 1
+  timestamp: 1
+  snapshot: 1
+  targets: 1

--- a/fixtures/PublishedTwiceWithRotatedKeys_timestamp/consistent/client_versions.ini
+++ b/fixtures/PublishedTwiceWithRotatedKeys_timestamp/consistent/client_versions.ini
@@ -1,4 +1,0 @@
-root = 1
-timestamp = 1
-snapshot = 1
-targets = 1

--- a/fixtures/PublishedTwiceWithRotatedKeys_timestamp/consistent/versions.yml
+++ b/fixtures/PublishedTwiceWithRotatedKeys_timestamp/consistent/versions.yml
@@ -3,3 +3,10 @@ start:
   timestamp: 1
   snapshot: 1
   targets: 1
+updated:
+  root: 2
+  # We expect the timestamp and snapshot metadata to be deleted from the client if the
+  # timestamp role's keys have been rotated.
+  timestamp: null
+  snapshot: null
+  targets: 1

--- a/fixtures/PublishedTwiceWithRotatedKeys_timestamp/consistent/versions.yml
+++ b/fixtures/PublishedTwiceWithRotatedKeys_timestamp/consistent/versions.yml
@@ -1,0 +1,5 @@
+start:
+  root: 1
+  timestamp: 1
+  snapshot: 1
+  targets: 1

--- a/fixtures/Simple/consistent/client_versions.ini
+++ b/fixtures/Simple/consistent/client_versions.ini
@@ -1,4 +1,0 @@
-root = 1
-timestamp = 1
-snapshot = 1
-targets = 1

--- a/fixtures/Simple/consistent/versions.yml
+++ b/fixtures/Simple/consistent/versions.yml
@@ -3,3 +3,8 @@ start:
   timestamp: 1
   snapshot: 1
   targets: 1
+updated:
+  root: 1
+  timestamp: 1
+  snapshot: 1
+  targets: 1

--- a/fixtures/Simple/consistent/versions.yml
+++ b/fixtures/Simple/consistent/versions.yml
@@ -1,0 +1,5 @@
+start:
+  root: 1
+  timestamp: 1
+  snapshot: 1
+  targets: 1

--- a/fixtures/TerminatingDelegation/consistent/client_versions.ini
+++ b/fixtures/TerminatingDelegation/consistent/client_versions.ini
@@ -1,4 +1,0 @@
-root = 1
-timestamp = 1
-snapshot = 1
-targets = 1

--- a/fixtures/TerminatingDelegation/consistent/versions.yml
+++ b/fixtures/TerminatingDelegation/consistent/versions.yml
@@ -1,0 +1,5 @@
+start:
+  root: 1
+  timestamp: 1
+  snapshot: 1
+  targets: 1

--- a/fixtures/ThreeLevelDelegation/consistent/client_versions.ini
+++ b/fixtures/ThreeLevelDelegation/consistent/client_versions.ini
@@ -1,4 +1,0 @@
-root = 1
-timestamp = 1
-snapshot = 1
-targets = 1

--- a/fixtures/ThreeLevelDelegation/consistent/versions.yml
+++ b/fixtures/ThreeLevelDelegation/consistent/versions.yml
@@ -1,0 +1,5 @@
+start:
+  root: 1
+  timestamp: 1
+  snapshot: 1
+  targets: 1

--- a/fixtures/ThresholdTwo/consistent/client_versions.ini
+++ b/fixtures/ThresholdTwo/consistent/client_versions.ini
@@ -1,4 +1,0 @@
-root = 1
-timestamp = 1
-snapshot = 1
-targets = 1

--- a/fixtures/ThresholdTwo/consistent/versions.yml
+++ b/fixtures/ThresholdTwo/consistent/versions.yml
@@ -1,0 +1,5 @@
+start:
+  root: 1
+  timestamp: 1
+  snapshot: 1
+  targets: 1

--- a/fixtures/ThresholdTwoAttack/consistent/client_versions.ini
+++ b/fixtures/ThresholdTwoAttack/consistent/client_versions.ini
@@ -1,4 +1,0 @@
-root = 2
-timestamp = 2
-snapshot = 1
-targets = 1

--- a/fixtures/ThresholdTwoAttack/consistent/versions.yml
+++ b/fixtures/ThresholdTwoAttack/consistent/versions.yml
@@ -1,0 +1,5 @@
+start:
+  root: 2
+  timestamp: 2
+  snapshot: 1
+  targets: 1

--- a/fixtures/TopLevelTerminating/consistent/client_versions.ini
+++ b/fixtures/TopLevelTerminating/consistent/client_versions.ini
@@ -1,4 +1,0 @@
-root = 1
-timestamp = 1
-snapshot = 1
-targets = 1

--- a/fixtures/TopLevelTerminating/consistent/versions.yml
+++ b/fixtures/TopLevelTerminating/consistent/versions.yml
@@ -1,0 +1,5 @@
+start:
+  root: 1
+  timestamp: 1
+  snapshot: 1
+  targets: 1

--- a/fixtures/UnsupportedDelegation/consistent/client_versions.ini
+++ b/fixtures/UnsupportedDelegation/consistent/client_versions.ini
@@ -1,6 +1,0 @@
-root = 1
-timestamp = 1
-snapshot = 1
-unsupported_target = null
-; We don't have an initial version of the `targets` role because it has an unsupported
-; field and would throw an exception when validating.

--- a/fixtures/UnsupportedDelegation/consistent/versions.yml
+++ b/fixtures/UnsupportedDelegation/consistent/versions.yml
@@ -1,0 +1,7 @@
+start:
+  root: 1
+  timestamp: 1
+  snapshot: 1
+  unsupported_target: null
+  # We don't have an initial version of the `targets` role because it has an unsupported
+  # field and would throw an exception when validating.

--- a/fixtures/UnsupportedDelegation/consistent/versions.yml
+++ b/fixtures/UnsupportedDelegation/consistent/versions.yml
@@ -5,3 +5,10 @@ start:
   unsupported_target: null
   # We don't have an initial version of the `targets` role because it has an unsupported
   # field and would throw an exception when validating.
+updated:
+  root: 2
+  timestamp: 2
+  snapshot: 2
+  unsupported_target: null
+  # We don't have an updated version of the `targets` role because it has an unsupported
+  # field and would throw an exception when validating.

--- a/fixtures/builder.py
+++ b/fixtures/builder.py
@@ -44,7 +44,7 @@ class FixtureBuilder:
     def __del__(self):
         # Create a hash for the generated fixture.
         with open(self.dir + "/hash.txt", "w") as hash_file:
-            hash_file.write(dirhash(self.dir, 'sha256', ignore=["__init__.py", "client_versions.ini", "hash.txt"]))
+            hash_file.write(dirhash(self.dir, 'sha256', ignore=["__init__.py", "versions.yml", "hash.txt"]))
 
     def _role(self, name):
         """Loads a role object for a specific role."""

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -82,7 +82,7 @@ class UpdaterTest extends TestCase
             }
         }
 
-        $expectedStartVersions = static::getClientStartVersions($fixtureName);
+        $expectedStartVersions = static::getVersions($fixtureName)['start'];
         $this->assertClientFileVersions($expectedStartVersions);
 
         $updater = new $updaterClass($this->serverStorage, $mirrors, $this->clientStorage);
@@ -831,7 +831,7 @@ class UpdaterTest extends TestCase
      */
     public function testRefreshRepository(string $fixtureName, array $expectedUpdatedVersions): void
     {
-        $expectedStartVersion = static::getClientStartVersions($fixtureName);
+        $expectedStartVersion = static::getVersions($fixtureName)['start'];
 
         $updater = $this->getSystemInTest($fixtureName);
         $this->assertTrue($updater->refresh($fixtureName));
@@ -1235,7 +1235,7 @@ class UpdaterTest extends TestCase
         // The updater is already refreshed, so this will return early, and
         // there should be no changes to the client-side repo.
         $updater->refresh();
-        $this->assertClientFileVersions(static::getClientStartVersions($fixtureName));
+        $this->assertClientFileVersions(static::getVersions($fixtureName)['start']);
         // If we force a refresh, the invalid state of the server-side repo will
         // raise an exception.
         $this->expectException(RepoFileNotFound::class);

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -1245,8 +1245,6 @@ class UpdaterTest extends TestCase
 
     /**
      * Tests that an exceptions for an repo with an unsupported field.
-     *
-     * @return void
      */
     public function testUnsupportedRepo(): void
     {
@@ -1261,14 +1259,7 @@ class UpdaterTest extends TestCase
             self::assertSame(1, preg_match("/$expectedMessage/s", $exception->getMessage()));
             // Assert that the root, timestamp and snapshot metadata files were updated
             // and that the unsupported_target metadata file was not downloaded.
-            $expectedUpdatedVersion = [
-                'root' => 2,
-                'timestamp' => 2,
-                'snapshot' => 2,
-                'unsupported_target' => null,
-                // We cannot assert the starting versions of 'targets' because it has
-                // an unsupported field and would throw an exception when validating.
-            ];
+            $expectedUpdatedVersion = static::getVersions($fixtureSet)['updated'];
             self::assertClientFileVersions($expectedUpdatedVersion);
             // Ensure that local version of targets has not changed because the
             // server version is invalid.

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -1285,14 +1285,10 @@ class UpdaterTest extends TestCase
      *   The fixtures set.
      * @param \Exception $expectedException
      *   The expected exception.
-     * @param array $expectedUpdatedVersions
-     *   The expected repo file version after refresh attempt.
-     *
-     * @return void
      *
      * @dataProvider providerAttackRepoException
      */
-    public function testAttackRepoException(string $fixtureName, \Exception $expectedException, array $expectedUpdatedVersions): void
+    public function testAttackRepoException(string $fixtureName, \Exception $expectedException): void
     {
         // Use the memory storage used so tests can write without permanent
         // side-effects.
@@ -1303,6 +1299,7 @@ class UpdaterTest extends TestCase
             $updater->refresh();
         } catch (TufException $exception) {
             $this->assertEquals($expectedException, $exception);
+            $expectedUpdatedVersions = static::getVersions($fixtureName)['updated'];
             $this->assertClientFileVersions($expectedUpdatedVersions);
             return;
         }
@@ -1322,12 +1319,6 @@ class UpdaterTest extends TestCase
             [
                 'AttackRollback',
                 new RollbackAttackException('Remote timestamp metadata version "$1" is less than previously seen timestamp version "$2"'),
-                [
-                    'root' => 2,
-                    'timestamp' => 2,
-                    'snapshot' => 2,
-                    'targets' => 2,
-                ],
             ],
         ];
     }

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -1337,32 +1337,12 @@ class UpdaterTest extends TestCase
         return [
             'not rotated' => [
                 'PublishedTwice',
-                [
-                    'root' => 2,
-                    'timestamp' => 1,
-                    'snapshot' => 1,
-                    'targets' => 1,
-                ],
             ],
-            // We expect the timestamp and snapshot metadata to be deleted from the client if either the
-            // timestamp or snapshot roles' keys have been rotated.
             'timestamp rotated' => [
                 'PublishedTwiceWithRotatedKeys_timestamp',
-                [
-                    'root' => 2,
-                    'timestamp' => null,
-                    'snapshot' => null,
-                    'targets' => 1,
-                ],
             ],
             'snapshot rotated' => [
                 'PublishedTwiceWithRotatedKeys_snapshot',
-                [
-                    'root' => 2,
-                    'timestamp' => null,
-                    'snapshot' => null,
-                    'targets' => 1,
-                ],
             ],
         ];
     }
@@ -1372,15 +1352,13 @@ class UpdaterTest extends TestCase
      *
      * @param string $fixtureName
      *   The name of the fixture to test with.
-     * @param array $expectedUpdatedVersions
-     *   The expected client-side versions of the TUF metadata after refresh.
      *
      * @dataProvider providerKeyRotation
      *
      * @covers ::hasRotatedKeys
      * @covers ::updateRoot
      */
-    public function testKeyRotation(string $fixtureName, array $expectedUpdatedVersions): void
+    public function testKeyRotation(string $fixtureName): void
     {
         $updater = $this->getSystemInTest($fixtureName);
         // This will purposefully cause the refresh to fail, immediately after
@@ -1392,6 +1370,7 @@ class UpdaterTest extends TestCase
         } catch (RepoFileNotFound $e) {
             // We don't need to do anything with this exception.
         }
+        $expectedUpdatedVersions = static::getVersions($fixtureName)['updated'];
         $this->assertClientFileVersions($expectedUpdatedVersions);
     }
 }

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -822,16 +822,14 @@ class UpdaterTest extends TestCase
      *
      * @param string $fixtureName
      *   The fixtures set to use.
-     * @param array $expectedUpdatedVersions
-     *   The expected updated versions.
-     *
-     * @return void
      *
      * @dataProvider providerRefreshRepository
      */
-    public function testRefreshRepository(string $fixtureName, array $expectedUpdatedVersions): void
+    public function testRefreshRepository(string $fixtureName): void
     {
-        $expectedStartVersion = static::getVersions($fixtureName)['start'];
+        $expectedVersions = static::getVersions($fixtureName);
+        $expectedStartVersion = $expectedVersions['start'];
+        $expectedUpdatedVersions = $expectedVersions['updated'];
 
         $updater = $this->getSystemInTest($fixtureName);
         $this->assertTrue($updater->refresh($fixtureName));
@@ -875,37 +873,9 @@ class UpdaterTest extends TestCase
     public function providerRefreshRepository(): array
     {
         return static::getKeyedArray([
-            [
-                'Delegated',
-                [
-                    'root' => 4,
-                    'timestamp' => 4,
-                    'snapshot' => 4,
-                    'targets' => 4,
-                    'unclaimed' => 1,
-                ],
-            ],
-            [
-                'Simple',
-                [
-                    'root' => 1,
-                    'timestamp' => 1,
-                    'snapshot' => 1,
-                    'targets' => 1,
-                ],
-            ],
-            [
-                'NestedDelegated',
-                [
-                    'root' => 5,
-                    'timestamp' => 5,
-                    'snapshot' => 5,
-                    'targets' => 5,
-                    'unclaimed' => 1,
-                    'level_2' => null,
-                    'level_3' => null,
-                ],
-            ],
+            ['Delegated'],
+            ['Simple'],
+            ['NestedDelegated'],
         ], 0);
     }
 

--- a/tests/TestHelpers/FixturesTrait.php
+++ b/tests/TestHelpers/FixturesTrait.php
@@ -3,6 +3,7 @@
 namespace Tuf\Tests\TestHelpers;
 
 use PHPUnit\Framework\Assert;
+use Symfony\Component\Yaml\Yaml;
 use Tuf\Metadata\RootMetadata;
 use Tuf\Metadata\SnapshotMetadata;
 use Tuf\Metadata\TargetsMetadata;
@@ -26,8 +27,8 @@ trait FixturesTrait
      */
     private static function getClientStartVersions(string $fixtureName): array
     {
-        $path = static::getFixturePath($fixtureName, 'client_versions.ini', false);
-        return parse_ini_file($path, false, INI_SCANNER_TYPED);
+        $path = static::getFixturePath($fixtureName, 'versions.yml', false);
+        return Yaml::parseFile($path)['start'];
     }
 
     /**

--- a/tests/TestHelpers/FixturesTrait.php
+++ b/tests/TestHelpers/FixturesTrait.php
@@ -16,19 +16,21 @@ use Tuf\Tests\TestHelpers\DurableStorage\MemoryStorage;
 trait FixturesTrait
 {
     /**
-     * Returns the initial client-side metadata versions for a fixture.
+     * Returns the expected metadata versions for a fixture.
      *
      * @param string $fixtureName
-     *     The name of the fixture to use.
+     *   The name of the fixture to use.
      *
-     * @return array
-     *   The expected versions of the initial client-side metadata, keyed by
-     *   role.
+     * @return array[]
+     *   An array with two elements: 'start' and 'updated'. The 'start' array
+     *   contains the expected versions of the initial client-side metadata,
+     *   keyed by role. The 'updated' array contains the expected versions of
+     *   the client-side metadata after a successful update, keyed by role.
      */
-    private static function getClientStartVersions(string $fixtureName): array
+    private static function getVersions(string $fixtureName): array
     {
-        $path = static::getFixturePath($fixtureName, 'versions.yml', false);
-        return Yaml::parseFile($path)['start'];
+        $file = static::getFixturePath($fixtureName, 'versions.yml', false);
+        return Yaml::parseFile($file);
     }
 
     /**


### PR DESCRIPTION
As I work to get #278 where it needs to be, I think it's becoming clear that we should double down on the concept introduced in #280, where the expected versions are encoded in a readable, comment-able file that's stored directly in the fixture.

The main benefit I think this will have is clarity. When you point a test case at a fixture, it will immediately know where it should start from, and where it should end up (assuming TUF doesn't throw an exception or abort the update).

@tedbow felt that the files should use YAML, and that's fine with me. It will necessitate adding a dev dependency on the Symfony YAML component (the YAML extension doesn't seem to install properly with PHP 8.2 on Windows).