### PR TITLE
Fix incorrect coverage annotations

### DIFF
--- a/tests/Client/ConsistentFixturesUpdaterTest.php
+++ b/tests/Client/ConsistentFixturesUpdaterTest.php
@@ -8,6 +8,8 @@ use Tuf\Exception\Attack\SignatureThresholdException;
  * Runs UpdaterTest's test cases on the fixtures with consistent snapshots.
  *
  * @testdox Updater with consistent snapshots
+ *
+ * @coversDefaultClass \Tuf\Client\Updater
  */
 class ConsistentFixturesUpdaterTest extends UpdaterTest
 {

--- a/tests/Client/InconsistentFixturesUpdaterTest.php
+++ b/tests/Client/InconsistentFixturesUpdaterTest.php
@@ -6,6 +6,8 @@ namespace Tuf\Tests\Client;
  * Runs UpdaterTest's test cases on the fixtures without consistent snapshots.
  *
  * @testdox Updater with non-consistent snapshots
+ *
+ * @coversDefaultClass \Tuf\Client\Updater
  */
 class InconsistentFixturesUpdaterTest extends UpdaterTest
 {

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -21,7 +21,7 @@ use Tuf\Tests\TestHelpers\TestClock;
 use Tuf\Tests\TestHelpers\UtilsTrait;
 
 /**
- * @coversDefaultClass \Tuf\Client\Updater
+ * Base class for testing the client update workflow.
  */
 abstract class UpdaterTest extends TestCase
 {

--- a/tests/Metadata/SnapshotMetadataTest.php
+++ b/tests/Metadata/SnapshotMetadataTest.php
@@ -5,6 +5,9 @@ namespace Tuf\Tests\Metadata;
 use Tuf\Metadata\MetadataBase;
 use Tuf\Metadata\SnapshotMetadata;
 
+/**
+ * @coversDefaultClass \Tuf\Metadata\SnapshotMetadata
+ */
 class SnapshotMetadataTest extends MetadataBaseTest
 {
     use UntrustedExceptionTrait;

--- a/tests/Metadata/TimestampMetadataTest.php
+++ b/tests/Metadata/TimestampMetadataTest.php
@@ -5,6 +5,9 @@ namespace Tuf\Tests\Metadata;
 use Tuf\Metadata\MetadataBase;
 use Tuf\Metadata\TimestampMetadata;
 
+/**
+ * @coversDefaultClass \Tuf\Metadata\TimestampMetadata
+ */
 class TimestampMetadataTest extends MetadataBaseTest
 {
     use UntrustedExceptionTrait;

--- a/tests/Unit/Client/VerifierTest.php
+++ b/tests/Unit/Client/VerifierTest.php
@@ -8,7 +8,7 @@ use Tuf\Metadata\Verifier\RootVerifier;
 use Tuf\Metadata\Verifier\VerifierBase;
 
 /**
- * @covers \Tuf\Metadata\Verifier\VerifierBase
+ * @coversDefaultClass \Tuf\Metadata\Verifier\VerifierBase
  */
 class VerifierTest extends TestCase
 {
@@ -60,7 +60,7 @@ class VerifierTest extends TestCase
      *
      * @return void
      */
-    public function testCheckRollbackAttackAttack(): void
+    public function testCheckRollbackAttack(): void
     {
         $this->expectException('\Tuf\Exception\Attack\RollbackAttackException');
         $this->expectExceptionMessage('Remote any metadata version "$1" is less than previously seen any version "$2"');

--- a/tests/Unit/GuzzleFileFetcherTest.php
+++ b/tests/Unit/GuzzleFileFetcherTest.php
@@ -148,7 +148,7 @@ class GuzzleFileFetcherTest extends TestCase
      *
      * @dataProvider providerFileIfExistsError
      *
-     * @covers ::providerFileIfExists
+     * @covers ::fetchMetadataIfExists
      */
     public function testFetchFileIfExistsError(int $statusCode, string $exceptionClass, ?int $exceptionCode = null, ?int $maxBytes = null): void
     {

--- a/tests/Unit/RoleTest.php
+++ b/tests/Unit/RoleTest.php
@@ -32,7 +32,7 @@ class RoleTest extends TestCase
     }
 
     /**
-     * @covers ::createFromMetadataAndName
+     * @covers ::createFromMetadata
      *
      * @param $data
      *   Invalid data.


### PR DESCRIPTION
Our coverage report (`composer coverage`) reports a lot of errors - that is, test methods which cover methods that don't exist. That's because our annotations aren't always correct.

This PR doesn't add or remove any coverage, but it does fix the wrong annotations so that PHPUnit can properly report what's covered and what's not.