### PR TITLE
Make metadata constraints easier to read by using default options for validation constraints

### DIFF
--- a/src/Metadata/ConstraintsTrait.php
+++ b/src/Metadata/ConstraintsTrait.php
@@ -135,7 +135,7 @@ trait ConstraintsTrait
             // is passed on from a setting in the Python `securesystemslib`
             // library.
             'keyid_hash_algorithms' => new Optional([
-                new EqualTo(["sha256", "sha512"]),
+                new EqualTo(['value' => ["sha256", "sha512"]]),
             ]),
             'keytype' => [
                 new Type('string'),

--- a/src/Metadata/ConstraintsTrait.php
+++ b/src/Metadata/ConstraintsTrait.php
@@ -60,7 +60,7 @@ trait ConstraintsTrait
                 new Type('\ArrayObject'),
               // The keys for 'hashes is not know but they all must be strings.
                 new All([
-                    new Type(['type' => 'string']),
+                    new Type('string'),
                     new NotBlank(),
                 ]),
             ],
@@ -77,7 +77,7 @@ trait ConstraintsTrait
     {
         return [
             'version' => [
-                new Type(['type' => 'integer']),
+                new Type('integer'),
                 new GreaterThanOrEqual(1),
             ],
         ];
@@ -93,7 +93,7 @@ trait ConstraintsTrait
     {
         return [
             'threshold' => [
-                new Type(['type' => 'integer']),
+                new Type('integer'),
                 new GreaterThanOrEqual(1),
             ],
         ];
@@ -109,10 +109,10 @@ trait ConstraintsTrait
         return [
             'keyids' => [
                 new Count(['min' => 1]),
-                new Type(['type' => 'array']),
+                new Type('array'),
                 // The keys for 'hashes is not know but they all must be strings.
                 new All([
-                    new Type(['type' => 'string']),
+                    new Type('string'),
                     new NotBlank(),
                 ]),
             ],
@@ -135,23 +135,23 @@ trait ConstraintsTrait
             // is passed on from a setting in the Python `securesystemslib`
             // library.
             'keyid_hash_algorithms' => new Optional([
-                new EqualTo(['value' => ["sha256", "sha512"]]),
+                new EqualTo(["sha256", "sha512"]),
             ]),
             'keytype' => [
-                new Type(['type' => 'string']),
+                new Type('string'),
                 new NotBlank(),
             ],
             'keyval' => [
                 new Type('\ArrayObject'),
                 new Collection([
                     'public' => [
-                        new Type(['type' => 'string']),
+                        new Type('string'),
                         new NotBlank(),
                     ],
                 ]),
             ],
             'scheme' => [
-                new Type(['type' => 'string']),
+                new Type('string'),
                 new NotBlank(),
             ],
         ]);

--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -135,15 +135,15 @@ abstract class MetadataBase
         return [
             'fields' => [
                 '_type' => [
-                    new EqualTo(['value' => static::TYPE]),
-                    new Type(['type' => 'string']),
+                    new EqualTo(static::TYPE),
+                    new Type('string'),
                 ],
                 'expires' => new DateTime(['value' => \DateTimeInterface::ISO8601]),
                 // We only expect to work with major version 1.
                 'spec_version' => [
                     new NotBlank(),
-                    new Type(['type' => 'string']),
-                    new Regex(['pattern' => '/^1\.[0-9]+\.[0-9]+$/']),
+                    new Type('string'),
+                    new Regex('/^1\.[0-9]+\.[0-9]+$/'),
                 ],
             ] + static::getVersionConstraints(),
             'allowExtraFields' => true,

--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -108,11 +108,11 @@ abstract class MetadataBase
                     new Collection([
                         'keyid' => [
                             new NotBlank(),
-                            new Type(['type' => 'string']),
+                            new Type('string'),
                         ],
                         'sig' => [
                             new NotBlank(),
-                            new Type(['type' => 'string']),
+                            new Type('string'),
                         ],
                     ]),
                 ]),

--- a/src/Metadata/TargetsMetadata.php
+++ b/src/Metadata/TargetsMetadata.php
@@ -62,17 +62,17 @@ class TargetsMetadata extends MetadataBase
                         'fields' => [
                             'name' => [
                                 new NotBlank(),
-                                new Type(['type' => 'string']),
+                                new Type('string'),
                             ],
                             'paths' => [
-                                new Type(['type' => 'array']),
+                                new Type('array'),
                                 new All([
-                                    new Type(['type' => 'string']),
+                                    new Type('string'),
                                     new NotBlank(),
                                 ]),
                             ],
                             'terminating' => [
-                                new Type(['type' => 'boolean']),
+                                new Type('boolean'),
                             ],
                         ] + static::getKeyidsConstraints() + static::getThresholdConstraints(),
                         // @todo Support 'path_hash_prefixes' in
@@ -86,7 +86,7 @@ class TargetsMetadata extends MetadataBase
             new All([
                 new Collection([
                     'length' => [
-                        new Type(['type' => 'integer']),
+                        new Type('integer'),
                         new GreaterThanOrEqual(1),
                     ],
                     'custom' => new Optional([

--- a/src/Metadata/TimestampMetadata.php
+++ b/src/Metadata/TimestampMetadata.php
@@ -28,7 +28,7 @@ class TimestampMetadata extends FileInfoMetadataBase
             new All([
                 new Collection([
                     'length' => [
-                        new Type(['type' => 'integer']),
+                        new Type('integer'),
                         new GreaterThanOrEqual(1),
                     ],
                 ] + static::getHashesConstraints() + static::getVersionConstraints()),


### PR DESCRIPTION
It'd be a little easier to read the validation constraints for metadata if we used the constraints' default options where possible. For example, things like `new Type(['type' => 'string'])` can always be converted to `new Type('string')`.

We already do this in several places, but I propose we make it consistent.