### PR TITLE
When downloading targets metadata, allow snapshot metadata to constrain the download size

### DIFF
--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -469,16 +469,13 @@ class Updater
      */
     private function fetchAndVerifyTargetsMetadata(string $role): void
     {
-        /** @var RootMetadata $rootMetadata */
-        $rootMetadata = $this->storage->getRoot();
-
-        $newSnapshotData = $this->storage->getSnapshot();
-        $targetsVersion = $newSnapshotData->getFileMetaInfo("$role.json")['version'];
+        $fileInfo = $this->storage->getSnapshot()->getFileMetaInfo("$role.json");
+        $targetsVersion = $fileInfo['version'];
         // § 5.6.1
-        $targetsFileName = $rootMetadata->supportsConsistentSnapshots()
+        $targetsFileName = $this->storage->getRoot()->supportsConsistentSnapshots()
             ? "$targetsVersion.$role.json"
             : "$role.json";
-        $newTargetsContent = $this->fetchFile($targetsFileName);
+        $newTargetsContent = $this->fetchFile($targetsFileName, $fileInfo['length'] ?? self::MAXIMUM_DOWNLOAD_BYTES);
         $newTargetsData = TargetsMetadata::createFromJson($newTargetsContent, $role);
         $this->universalVerifier->verify(TargetsMetadata::TYPE, $newTargetsData);
         // § 5.5.6


### PR DESCRIPTION
According to the TUF spec, the snapshot can define _optional_ lengths for target metadata files: https://theupdateframework.github.io/specification/latest/#metapath-length.

> An integer length in bytes of the metadata file at [METAPATH](https://theupdateframework.github.io/specification/latest/#snapshot-metapath). It is OPTIONAL and can be omitted to reduce the snapshot metadata file size. In that case the client MUST use a custom download limit for the listed metadata.

Right now, we don't support this. We always (implicitly) constrain the download size of targets metadata, and any delegated roles, to Updater::MAXIMUM_DOWNLOAD_BYTES. Instead, we should default to that only if the snapshot doesn't define a length.