### PR TITLE
Remove mirror support from Updater

### DIFF
--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -43,11 +43,6 @@ class Updater
     const MAXIMUM_TARGET_ROLES = 100;
 
     /**
-     * @var \array[][]
-     */
-    protected $mirrors;
-
-    /**
      * The permanent storage (e.g., filesystem storage) for the client metadata.
      *
      * @var \Tuf\Metadata\StorageInterface
@@ -100,24 +95,13 @@ class Updater
      *
      * @param \Tuf\Client\RepoFileFetcherInterface $repoFileFetcher
      *     The repo fetcher.
-     * @param mixed[][] $mirrors
-     *     A nested array of mirrors to use for fetching signing data from the
-     *     repository. Each child array contains information about the mirror:
-     *     - url_prefix: (string) The URL for the mirror.
-     *     - metadata_path: (string) The path within the repository for signing
-     *       metadata.
-     *     - targets_path: (string) The path within the repository for targets
-     *       (the actual update data that has been signed).
-     *     - confined_target_dirs: (array) @todo What is this for?
-     *       https://github.com/php-tuf/php-tuf/issues/161
      *  @param \Tuf\Metadata\StorageInterface $storage
      *     The storage backend for trusted metadata. Should be available to
      *     future instances of Updater that interact with the same repository.
      */
-    public function __construct(RepoFileFetcherInterface $repoFileFetcher, array $mirrors, StorageInterface $storage)
+    public function __construct(RepoFileFetcherInterface $repoFileFetcher, StorageInterface $storage)
     {
         $this->repoFileFetcher = $repoFileFetcher;
-        $this->mirrors = $mirrors;
         $this->storage = $storage;
         $this->clock = new Clock();
     }

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -70,15 +70,6 @@ abstract class UpdaterTest extends TestCase
      */
     protected function getSystemInTest(string $fixtureName, string $updaterClass = Updater::class): Updater
     {
-        $mirrors = [
-            'mirror1' => [
-                'url_prefix' => 'http://localhost:8001',
-                'metadata_path' => 'metadata',
-                'targets_path' => 'targets',
-                'confined_target_dirs' => [],
-            ],
-        ];
-
         $this->clientStorage = static::loadFixtureIntoMemory($fixtureName);
         $this->serverStorage = new TestRepo(static::getFixturePath($fixtureName));
 
@@ -94,7 +85,7 @@ abstract class UpdaterTest extends TestCase
         $expectedStartVersions = static::getClientStartVersions($fixtureName);
         $this->assertClientFileVersions($expectedStartVersions);
 
-        $updater = new $updaterClass($this->serverStorage, $mirrors, $this->clientStorage);
+        $updater = new $updaterClass($this->serverStorage, $this->clientStorage);
         // Force the updater to use our test clock so that, like supervillains,
         // we control what time it is.
         $reflector = new \ReflectionObject($updater);


### PR DESCRIPTION
So Updater has a $mirrors property which is not used for anything. UpdaterTest::getSystemInTest() passes something to it, but...it's not used inside Updater for anything.

Really, we just don't support mirrors right now (and might not before 1.0.0). Therefore, we should remove this code.