### PR TITLE
Remove --three from pipenv install in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         python -m pip install --upgrade pipenv
     - name: Install dependencies via pipenv
       run: |
-        if [ -f Pipfile.lock ]; then pipenv --three install; fi
+        if [ -f Pipfile.lock ]; then pipenv install; fi
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names


### PR DESCRIPTION
CI builds are failing because we're calling `pipenv install --three`, which is no longer supported (and indeed, it's been warning us about that for a while but we've been cheerfully ignoring it).