### PR TITLE
Support non-seekable streams in SizeCheckingLoader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
         "slevomat/coding-standard": "^8.2",
         "phpspec/prophecy-phpunit": "^2",
         "guzzlehttp/guzzle": "^6.5 || ^7.2",
-        "guzzlehttp/psr7": "^1.7",
         "phpspec/prophecy": "^1.16"
     },
     "license": "MIT",
@@ -21,7 +20,8 @@
         "paragonie/sodium_compat": "^1.13",
         "symfony/validator": "^4.4 || ^5 || ^6",
         "myclabs/deep-copy": "^1.10.2",
-        "psr/http-message": "^1"
+        "psr/http-message": "^1",
+        "guzzlehttp/psr7": "^1.7"
     },
     "suggest": {
         "ext-sodium": "Provides faster verification of updates",

--- a/src/Loader/SizeCheckingLoader.php
+++ b/src/Loader/SizeCheckingLoader.php
@@ -32,6 +32,11 @@ class SizeCheckingLoader implements LoaderInterface
     /**
      * Tries to determine the size of a stream, up to $maxBytes.
      *
+     * This method has intentional side effects. If the stream isn't seekable
+     * and its size is unknown, up to $maxBytes of the incoming data will be
+     * copied into a new stream, which will be referenced by the $stream
+     * parameter. Data that was already in the original stream will be lost!
+     *
      * @param \Psr\Http\Message\StreamInterface $stream
      *   A data stream.
      * @param int $maxBytes

--- a/src/Loader/SizeCheckingLoader.php
+++ b/src/Loader/SizeCheckingLoader.php
@@ -70,6 +70,8 @@ class SizeCheckingLoader implements LoaderInterface
         // do trust.
         $buffer = Utils::tryFopen('php://temp', 'a');
         $replacementStream = Utils::streamFor($buffer);
+        // Read $maxBytes + 1 to detect if there is any data in the stream
+        // beyond $maxBytes (there shouldn't be).
         $size = $replacementStream->write($stream->read($maxBytes + 1));
         $stream = $replacementStream;
         $stream->rewind();

--- a/src/Loader/SizeCheckingLoader.php
+++ b/src/Loader/SizeCheckingLoader.php
@@ -72,6 +72,7 @@ class SizeCheckingLoader implements LoaderInterface
         $replacementStream = Utils::streamFor($buffer);
         $size = $replacementStream->write($stream->read($maxBytes + 1));
         $stream = $replacementStream;
+        $stream->rewind();
         return $size;
     }
 }

--- a/src/Loader/SizeCheckingLoader.php
+++ b/src/Loader/SizeCheckingLoader.php
@@ -2,6 +2,7 @@
 
 namespace Tuf\Loader;
 
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\StreamInterface;
 use Tuf\Exception\DownloadSizeException;
 
@@ -21,24 +22,61 @@ class SizeCheckingLoader implements LoaderInterface
     {
         $data = $this->decorated->load($locator, $maxBytes);
 
-        $error = new DownloadSizeException("$locator exceeded $maxBytes bytes");
-
-        $size = $data->getSize();
-        if ($size === null) {
-            // @todo Handle non-seekable streams.
-            // https://github.com/php-tuf/php-tuf/issues/169
-            $data->rewind();
-            $data->read($maxBytes);
-
-            // If we reached the end of the stream, we didn't exceed the
-            // maximum number of bytes.
-            if ($data->eof() === false) {
-                throw $error;
-            }
-            $data->rewind();
-        } elseif ($size > $maxBytes) {
-            throw $error;
+        $size = $this->getSize($data, $maxBytes);
+        if ($size > $maxBytes) {
+            throw new DownloadSizeException("$locator exceeded $maxBytes bytes");
         }
         return $data;
+    }
+
+    /**
+     * Tries to determine the size of a stream, up to $maxBytes.
+     *
+     * @param \Psr\Http\Message\StreamInterface $stream
+     *   A data stream.
+     * @param int $maxBytes
+     *   The maximum number of bytes that will be read from the stream if its
+     *   size is not known, and it's not seekable.
+     *
+     * @return int
+     *   The estimated size of the stream.
+     */
+    private function getSize(StreamInterface &$stream, int $maxBytes): int
+    {
+        // If the stream knows how big it is, believe it.
+        $size = $stream->getSize();
+        if (isset($size)) {
+            return $size;
+        }
+
+        // If the stream is seekable, skip to the end and tell where we are.
+        if ($stream->isSeekable()) {
+            // Remember our position, so we can go back there before returning.
+            $originalPosition = $stream->tell();
+            $stream->seek(0, SEEK_END);
+            $size = $stream->tell();
+            $stream->seek($originalPosition);
+            return $size;
+        }
+
+        // If we get here, we truly don't know how much data we're dealing with.
+        // So, treat everything that has already come through the stream as
+        // untrusted, and read up to $maxBytes into a new stream whose size we
+        // do trust.
+        $buffer = Utils::tryFopen('php://temp', 'a');
+        $replacementStream = Utils::streamFor($buffer);
+        $bytesCopied = 0;
+        // Transfer incoming data to the replacement stream, one byte at a time,
+        // until we either reach the end of the original stream, or we copy
+        // $maxBytes.
+        while ($bytesCopied <= $maxBytes && $stream->eof() === false) {
+            $replacementStream->write($stream->read(1));
+            // Even if the byte wasn't copied to $replacementStream, increment
+            // $bytesCopied, since our main goal here is to measure the size of
+            // the stream.
+            $bytesCopied++;
+        }
+        $stream = $replacementStream;
+        return $bytesCopied;
     }
 }

--- a/src/Loader/SizeCheckingLoader.php
+++ b/src/Loader/SizeCheckingLoader.php
@@ -70,18 +70,8 @@ class SizeCheckingLoader implements LoaderInterface
         // do trust.
         $buffer = Utils::tryFopen('php://temp', 'a');
         $replacementStream = Utils::streamFor($buffer);
-        $bytesCopied = 0;
-        // Transfer incoming data to the replacement stream, one byte at a time,
-        // until we either reach the end of the original stream, or we copy
-        // $maxBytes.
-        while ($bytesCopied <= $maxBytes && $stream->eof() === false) {
-            $replacementStream->write($stream->read(1));
-            // Even if the byte wasn't copied to $replacementStream, increment
-            // $bytesCopied, since our main goal here is to measure the size of
-            // the stream.
-            $bytesCopied++;
-        }
+        $size = $replacementStream->write($stream->read($maxBytes + 1));
         $stream = $replacementStream;
-        return $bytesCopied;
+        return $size;
     }
 }

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -154,8 +154,7 @@ abstract class UpdaterTest extends TestCase
         $stream = $this->prophesize('\Psr\Http\Message\StreamInterface');
         $stream->getSize()->willReturn(null);
         $stream->isSeekable()->willReturn(false);
-        $stream->read(1)->willReturn('a')->shouldBeCalledTimes(25);
-        $stream->eof()->willReturn(false);
+        $stream->read(25)->willReturn('The quick brown fox jumped over the lazy dogs.');
         $this->serverStorage->fileContents['testtarget.txt'] = $stream->reveal();
         try {
             $updater->download('testtarget.txt');

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -138,30 +138,6 @@ abstract class UpdaterTest extends TestCase
             $this->assertSame("Invalid sha256 hash for testtarget.txt", $e->getMessage());
             $this->assertSame($stream, $e->getStream());
         }
-
-        // If the stream is longer than expected, we should get an exception,
-        // whether or not the stream's length is known.
-        $stream = $this->prophesize('\Psr\Http\Message\StreamInterface');
-        $stream->getSize()->willReturn(1024);
-        $this->serverStorage->fileContents['testtarget.txt'] = $stream->reveal();
-        try {
-            $updater->download('testtarget.txt');
-            $this->fail('Expected DownloadSizeException to be thrown, but it was not.');
-        } catch (DownloadSizeException $e) {
-            $this->assertSame("testtarget.txt exceeded 24 bytes", $e->getMessage());
-        }
-
-        $stream = $this->prophesize('\Psr\Http\Message\StreamInterface');
-        $stream->getSize()->willReturn(null);
-        $stream->isSeekable()->willReturn(false);
-        $stream->read(25)->willReturn('The quick brown fox jumped over the lazy dogs.');
-        $this->serverStorage->fileContents['testtarget.txt'] = $stream->reveal();
-        try {
-            $updater->download('testtarget.txt');
-            $this->fail('Expected DownloadSizeException to be thrown, but it was not.');
-        } catch (DownloadSizeException $e) {
-            $this->assertSame("testtarget.txt exceeded 24 bytes", $e->getMessage());
-        }
     }
 
     /**

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -153,8 +153,8 @@ abstract class UpdaterTest extends TestCase
 
         $stream = $this->prophesize('\Psr\Http\Message\StreamInterface');
         $stream->getSize()->willReturn(null);
-        $stream->rewind()->shouldBeCalledOnce();
-        $stream->read(24)->willReturn('A nice, long string that is certainly longer than 24 bytes.');
+        $stream->isSeekable()->willReturn(false);
+        $stream->read(1)->willReturn('a')->shouldBeCalledTimes(25);
         $stream->eof()->willReturn(false);
         $this->serverStorage->fileContents['testtarget.txt'] = $stream->reveal();
         try {

--- a/tests/Unit/SizeCheckingLoaderTest.php
+++ b/tests/Unit/SizeCheckingLoaderTest.php
@@ -2,7 +2,6 @@
 
 namespace Tuf\Tests\Unit;
 
-use GuzzleHttp\Psr7\NoSeekStream;
 use GuzzleHttp\Psr7\Stream;
 use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
@@ -86,14 +85,19 @@ class SizeCheckingLoaderTest extends TestCase implements LoaderInterface
         $buffer = Utils::tryFopen('php://temp', 'a+');
 
         // Make the stream non-seekable, forcing the loader to read from it.
-        $this->stream = new NoSeekStream(new class ($buffer) extends Stream {
+        $this->stream = new class ($buffer) extends Stream {
 
             public function getSize()
             {
                 return null;
             }
 
-        });
+            public function isSeekable()
+            {
+                return false;
+            }
+
+        };
 
         // Write 8 bytes, and then return to the start of the stream so we can
         // read them back.

--- a/tests/Unit/SizeCheckingLoaderTest.php
+++ b/tests/Unit/SizeCheckingLoaderTest.php
@@ -107,8 +107,8 @@ class SizeCheckingLoaderTest extends TestCase implements LoaderInterface
         // Write another byte, and return to the start of the stream.
         $this->stream->write('*');
         $this->assertSame(0, fseek($buffer, 0), 'Failed to return to the start of the stream.');
-        // If there is more data to read beyond $maxBytes, we should get an
-        // exception.
+        // Since there is now more data to read beyond $maxBytes, we should get
+        // an exception.
         $this->expectException(DownloadSizeException::class);
         $this->expectExceptionMessage('too_long.txt exceeded 8 bytes');
         $this->loader->load('too_long.txt', 8);

--- a/tests/Unit/SizeCheckingLoaderTest.php
+++ b/tests/Unit/SizeCheckingLoaderTest.php
@@ -2,6 +2,7 @@
 
 namespace Tuf\Tests\Unit;
 
+use GuzzleHttp\Psr7\NoSeekStream;
 use GuzzleHttp\Psr7\Stream;
 use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
@@ -17,6 +18,17 @@ class SizeCheckingLoaderTest extends TestCase implements LoaderInterface
 {
     private StreamInterface $stream;
 
+    private SizeCheckingLoader $loader;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->loader = new SizeCheckingLoader($this);
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -25,28 +37,24 @@ class SizeCheckingLoaderTest extends TestCase implements LoaderInterface
         return $this->stream;
     }
 
-    public function testStreamSizeIsChecked(): void
+    public function testKnownSize(): void
     {
-        $loader = new SizeCheckingLoader($this);
-
-        // If $maxBytes is bigger than the size of the stream, we shouldn't have
-        // a problem.
         $this->stream = Utils::streamFor('Deep Space Nine is the best Star Trek series. This is a scientific fact.');
-        $loader->load('ok.txt', 1024);
-
-        // If the size of the stream is known, we should get an error if it's
-        // longer than $maxBytes.
         $this->assertGreaterThan(0, $this->stream->getSize());
-        try {
-            $loader->load('too_long_known_size.txt', 8);
-            $this->fail('Expected DownloadSizeException to be thrown, but it was not.');
-        } catch (DownloadSizeException $e) {
-            $this->assertSame('too_long_known_size.txt exceeded 8 bytes', $e->getMessage());
-        }
 
-        // Make a new stream that doesn't know how long it is, but is seekable,
-        // and ensure we still get an error if it's longer than $maxBytes.
-        $buffer = $this->stream->detach();
+        // If the size is known, the stream should not be replaced.
+        $this->assertSame($this->stream, $this->loader->load('ok.txt', 1024));
+
+        $this->expectException(DownloadSizeException::class);
+        $this->expectExceptionMessage('too_long.txt exceeded 8 bytes');
+        $this->loader->load('too_long.txt', 8);
+    }
+
+    public function testSeekableUnknownSize(): void
+    {
+        $buffer = Utils::streamFor('Deep Space Nine is the best Star Trek series. This is a scientific fact.')
+            ->detach();
+
         $this->stream = new class ($buffer) extends Stream {
 
             public function getSize()
@@ -56,16 +64,53 @@ class SizeCheckingLoaderTest extends TestCase implements LoaderInterface
 
         };
         $this->assertTrue($this->stream->isSeekable());
+
+        // If the stream is seekable, it should not be replaced.
+        $this->assertSame($this->stream, $this->loader->load('ok.txt', 1024));
+
         $this->assertSame(0, $this->stream->tell());
         // Move the stream to a different position so we can ensure the size
         // check returns us there.
         $this->stream->seek(8);
         try {
-            $loader->load('too_long_unknown_size.txt', 8);
+            $this->loader->load('too_long.txt', 8);
             $this->fail('Expected DownloadSizeException to be thrown, but it was not.');
         } catch (DownloadSizeException $e) {
-            $this->assertSame('too_long_unknown_size.txt exceeded 8 bytes', $e->getMessage());
+            $this->assertSame('too_long.txt exceeded 8 bytes', $e->getMessage());
             $this->assertSame(8, $this->stream->tell());
         }
+    }
+
+    public function testNonSeekableUnknownSize(): void
+    {
+        $buffer = Utils::tryFopen('php://temp', 'a+');
+
+        // Make the stream non-seekable, forcing the loader to read from it.
+        $this->stream = new NoSeekStream(new class ($buffer) extends Stream {
+
+            public function getSize()
+            {
+                return null;
+            }
+
+        });
+
+        // Write 8 bytes, and then return to the start of the stream so we can
+        // read them back.
+        $this->stream->write(str_repeat('*', 8));
+        // fseek() returns 0 on success.
+        $this->assertSame(0, fseek($buffer, 0), 'Failed to return to the start of the stream.');
+        // Even if the stream did not exceed $maxBytes, it should have been
+        // replaced with a new stream.
+        $this->assertNotSame($this->stream, $this->loader->load('ok.txt', 8));
+
+        // Write another byte, and return to the start of the stream.
+        $this->stream->write('*');
+        $this->assertSame(0, fseek($buffer, 0), 'Failed to return to the start of the stream.');
+        // If there is more data to read beyond $maxBytes, we should get an
+        // exception.
+        $this->expectException(DownloadSizeException::class);
+        $this->expectExceptionMessage('too_long.txt exceeded 8 bytes');
+        $this->loader->load('too_long.txt', 8);
     }
 }

--- a/tests/Unit/SizeCheckingLoaderTest.php
+++ b/tests/Unit/SizeCheckingLoaderTest.php
@@ -106,7 +106,9 @@ class SizeCheckingLoaderTest extends TestCase implements LoaderInterface
         $this->assertSame(0, fseek($buffer, 0), 'Failed to return to the start of the stream.');
         // Even if the stream did not exceed $maxBytes, it should have been
         // replaced with a new stream.
-        $this->assertNotSame($this->stream, $this->loader->load('ok.txt', 8));
+        $replacementStream = $this->loader->load('ok.txt', 8);
+        $this->assertNotSame($this->stream, $replacementStream);
+        $this->assertSame(0, $replacementStream->tell());
 
         // Write another byte, and return to the start of the stream.
         $this->stream->write('*');


### PR DESCRIPTION
Fixes #169.