### PR TITLE
Require guzzlehttp/psr7 to 2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/validator": "^4.4 || ^5 || ^6",
         "myclabs/deep-copy": "^1.10.2",
         "psr/http-message": "^1",
-        "guzzlehttp/psr7": "^1.7"
+        "guzzlehttp/psr7": "^2.4"
     },
     "suggest": {
         "ext-sodium": "Provides faster verification of updates",

--- a/tests/Unit/SizeCheckingLoaderTest.php
+++ b/tests/Unit/SizeCheckingLoaderTest.php
@@ -56,7 +56,7 @@ class SizeCheckingLoaderTest extends TestCase implements LoaderInterface
 
         $this->stream = new class ($buffer) extends Stream {
 
-            public function getSize()
+            public function getSize(): ?int
             {
                 return null;
             }
@@ -87,12 +87,12 @@ class SizeCheckingLoaderTest extends TestCase implements LoaderInterface
         // Make the stream non-seekable, forcing the loader to read from it.
         $this->stream = new class ($buffer) extends Stream {
 
-            public function getSize()
+            public function getSize(): ?int
             {
                 return null;
             }
 
-            public function isSeekable()
+            public function isSeekable(): bool
             {
                 return false;
             }


### PR DESCRIPTION
We currently use guzzlehttp/psr7 v1, but it's not compatible with Drupal 10, which requires 2.4 or later. I don't see any real reason not to bump our constraint.