### PR TITLE
Require only supported versions of symfony/validator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,8 +82,8 @@ jobs:
         # See https://github.com/composer/composer/issues/10943
         dependencies:
           - 'symfony/validator:~4.4'
-          - 'symfony/validator:~5.0'
-          - 'symfony/validator:~6.0'
+          - 'symfony/validator:~5.4'
+          - 'symfony/validator:~6.2'
         experimental: [false]
         include:
           - operating-system: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^8",
         "ext-json": "*",
         "paragonie/sodium_compat": "^1.13",
-        "symfony/validator": "^4.4 || ^5 || ^6",
+        "symfony/validator": "^4.4 || ^5.4 || ^6.2",
         "myclabs/deep-copy": "^1.10.2",
         "psr/http-message": "^1",
         "guzzlehttp/psr7": "^2.4"


### PR DESCRIPTION
According to https://endoflife.date/symfony, all Symfony 5 versions before 5.4 and Symfony 6 versions before 6.2 are EOL. We should bump our constraints to prevent older versions from being accidentally installed.