### PR TITLE
Remove direct dependency on psr/http-message

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "paragonie/sodium_compat": "^1.13",
         "symfony/validator": "^4.4 || ^5 || ^6",
         "myclabs/deep-copy": "^1.10.2",
-        "psr/http-message": "^1",
         "guzzlehttp/psr7": "^2.4"
     },
     "suggest": {


### PR DESCRIPTION
I'm not convinced we need this as a direct dependency.

We already have a hard dependency on guzzlehttp/psr7, which is by definition an implementation of the interfaces in psr/http-message. So it seems redundant to also depend on psr/http-message. I propose we remove it until -- and if -- we remove guzzlehttp/psr7.