### PR TITLE
Remove guzzlehttp/guzzle from composer.json suggestions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
         "guzzlehttp/psr7": "^2.4"
     },
     "suggest": {
-        "ext-sodium": "Provides faster verification of updates",
-        "guzzlehttp/guzzle": "Required package if GuzzleFileFetcher shall be used"
+        "ext-sodium": "Provides faster verification of updates"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
So...since #297, we no longer have any use of the Guzzle HTTP client. So, the suggestion in composer.json to install it is not accurate anymore and should be removed.