### PR TITLE
Adopt typed properties and constructor property promotion

### DIFF
--- a/src/Client/DurableStorage/FileStorage.php
+++ b/src/Client/DurableStorage/FileStorage.php
@@ -13,12 +13,6 @@ use Tuf\Metadata\StorageBase;
 class FileStorage extends StorageBase
 {
     /**
-     * @var string $basePath
-     *     The path on the filesystem to this durable storage's files.
-     */
-    protected $basePath;
-
-    /**
      * Constructs a new FileStorage instance.
      *
      * @param string $basePath
@@ -27,13 +21,11 @@ class FileStorage extends StorageBase
      * @throws \RuntimeException
      *     Thrown if the base path is not an accessible, existing directory.
      */
-    public function __construct(string $basePath)
+    public function __construct(protected string $basePath)
     {
         if (! is_dir($basePath)) {
             throw new \RuntimeException("Cannot initialize filesystem local state: '$basePath' is not a directory.");
         }
-
-        $this->basePath = $basePath;
     }
 
     /**

--- a/src/Client/SignatureVerifier.php
+++ b/src/Client/SignatureVerifier.php
@@ -17,22 +17,10 @@ use Tuf\RoleDB;
 final class SignatureVerifier
 {
     /**
-     * @var \Tuf\RoleDB
-     */
-    private $roleDb;
-
-    /**
-     * @var \Tuf\KeyDB
-     */
-    private $keyDb;
-
-    /**
      * SignatureVerifier constructor.
      */
-    private function __construct(RoleDB $roleDb, KeyDB $keyDb)
+    private function __construct(private RoleDB $roleDb, private KeyDB $keyDb)
     {
-        $this->roleDb = $roleDb;
-        $this->keyDb = $keyDb;
     }
 
     /**

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -59,7 +59,7 @@ class Updater
      *
      * @var \DateTimeImmutable
      */
-    private \DateTimeImmutable $metadataExpiration;
+    private ?\DateTimeImmutable $metadataExpiration;
 
     /**
      * The verifier factory.

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -42,31 +42,31 @@ class Updater
      *
      * @var bool
      */
-    protected $isRefreshed = false;
+    protected bool $isRefreshed = false;
 
     /**
      * @var \Tuf\Client\SignatureVerifier
      */
-    protected $signatureVerifier;
+    protected SignatureVerifier $signatureVerifier;
 
     /**
      * @var \Tuf\Helper\Clock
      */
-    protected $clock;
+    protected Clock $clock;
 
     /**
      * The time after which metadata should be considered expired.
      *
      * @var \DateTimeImmutable
      */
-    private $metadataExpiration;
+    private \DateTimeImmutable $metadataExpiration;
 
     /**
      * The verifier factory.
      *
      * @var \Tuf\Metadata\Verifier\UniversalVerifier
      */
-    protected $universalVerifier;
+    protected UniversalVerifier $universalVerifier;
 
     /**
      * The backend to load untrusted metadata from the server.

--- a/src/DelegatedRole.php
+++ b/src/DelegatedRole.php
@@ -12,17 +12,6 @@ use Symfony\Component\Validator\Constraints\Type;
  */
 class DelegatedRole extends Role
 {
-
-    /**
-     * @var string[]
-     */
-    protected $paths;
-
-    /**
-     * @var bool
-     */
-    protected $terminating;
-
     /**
      * @return bool
      */
@@ -40,11 +29,9 @@ class DelegatedRole extends Role
      * @param array $paths
      * @param bool $terminating
      */
-    private function __construct(string $name, int $threshold, array $keyIds, array $paths, bool $terminating)
+    private function __construct(string $name, int $threshold, array $keyIds, protected array $paths, protected bool $terminating)
     {
         parent::__construct($name, $threshold, $keyIds);
-        $this->paths = $paths;
-        $this->terminating = $terminating;
     }
 
     public static function createFromMetadata(\ArrayObject $roleInfo, string $name = null): Role

--- a/src/Exception/Attack/InvalidHashException.php
+++ b/src/Exception/Attack/InvalidHashException.php
@@ -16,17 +16,6 @@ use Tuf\Exception\TufException;
 class InvalidHashException extends TufException
 {
     /**
-     * An untrusted stream object pointing to the downloaded target.
-     *
-     * WARNING: The contents of the stream failed TUF validation. Any code
-     * interacting with this stream should treat it as unsafe and proceed with
-     * great caution.
-     *
-     * @var \Psr\Http\Message\StreamInterface
-     */
-    private $stream;
-
-    /**
      * InvalidHashException constructor.
      *
      * @param \Psr\Http\Message\StreamInterface $stream
@@ -41,10 +30,9 @@ class InvalidHashException extends TufException
      * @param \Throwable|null $previous
      *   The previous exception, if any.
      */
-    public function __construct(StreamInterface $stream, $message = "", $code = 0, \Throwable $previous = null)
+    public function __construct(private StreamInterface $stream, $message = "", $code = 0, \Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
-        $this->stream = $stream;
     }
 
     /**

--- a/src/Key.php
+++ b/src/Key.php
@@ -12,27 +12,6 @@ final class Key
     use ConstraintsTrait;
 
     /**
-     * The key type.
-     *
-     * @var string
-     */
-    private $type;
-
-    /**
-     * The key scheme.
-     *
-     * @var string
-     */
-    private $scheme;
-
-    /**
-     * The public key value.
-     *
-     * @var string
-     */
-    private $public;
-
-    /**
      * Key constructor.
      *
      * @param string $type
@@ -42,11 +21,8 @@ final class Key
      * @param string $public
      *   The public key value.
      */
-    private function __construct(string $type, string $scheme, string $public)
+    private function __construct(private string $type, private string $scheme, private string $public)
     {
-        $this->type = $type;
-        $this->scheme = $scheme;
-        $this->public = $public;
     }
 
     /**

--- a/src/KeyDB.php
+++ b/src/KeyDB.php
@@ -22,6 +22,13 @@ use Tuf\Metadata\RootMetadata;
 class KeyDB
 {
     /**
+     * A set of keys, indexed by key ID.
+     *
+     * @var array[]
+     */
+    protected array $keys = [];
+
+    /**
      * Creates a key database with the unique keys found in root metadata.
      *
      * @param \Tuf\Metadata\RootMetadata $rootMetadata
@@ -59,15 +66,6 @@ class KeyDB
         return ['ed25519'];
     }
 
-    /**
-     * Constructs a new KeyDB.
-     *
-     * @param array $keys
-     *   Keys indexed by key ID.
-     */
-    public function __construct(protected array $keys = [])
-    {
-    }
 
     /**
      * Adds key metadata to the key database while avoiding duplicates.

--- a/src/KeyDB.php
+++ b/src/KeyDB.php
@@ -22,13 +22,6 @@ use Tuf\Metadata\RootMetadata;
 class KeyDB
 {
     /**
-     * Keys indexed by key ID.
-     *
-     * @var \array[]
-     */
-    protected $keys;
-
-    /**
      * Creates a key database with the unique keys found in root metadata.
      *
      * @param \Tuf\Metadata\RootMetadata $rootMetadata
@@ -68,10 +61,12 @@ class KeyDB
 
     /**
      * Constructs a new KeyDB.
+     *
+     * @param array $keys
+     *   Keys indexed by key ID.
      */
-    public function __construct()
+    public function __construct(protected array $keys = [])
     {
-        $this->keys = [];
     }
 
     /**

--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -22,13 +22,6 @@ abstract class MetadataBase
     use ConstraintsTrait;
 
     /**
-     * The metadata.
-     *
-     * @var array
-     */
-    protected $metadata;
-
-    /**
      * Metadata type.
      *
      * @var string
@@ -36,16 +29,11 @@ abstract class MetadataBase
     protected const TYPE = '';
 
     /**
-     * @var string
-     */
-    private $sourceJson;
-
-    /**
      * Whether the metadata has been verified and should be considered trusted.
      *
      * @var bool
      */
-    private $isTrusted = false;
+    private bool $isTrusted = false;
 
 
     /**
@@ -56,10 +44,8 @@ abstract class MetadataBase
      * @param string $sourceJson
      *   The source JSON.
      */
-    public function __construct(\ArrayObject $metadata, string $sourceJson)
+    public function __construct(protected \ArrayObject $metadata, protected string $sourceJson)
     {
-        $this->metadata = $metadata;
-        $this->sourceJson = $sourceJson;
     }
 
     /**
@@ -68,7 +54,7 @@ abstract class MetadataBase
      * @return string
      *   The JSON source.
      */
-    public function getSource():string
+    public function getSource(): string
     {
         return $this->sourceJson;
     }
@@ -85,7 +71,7 @@ abstract class MetadataBase
      * @throws \Tuf\Exception\MetadataException
      *   Thrown if validation fails.
      */
-    public static function createFromJson(string $json): self
+    public static function createFromJson(string $json): static
     {
         $data = JsonNormalizer::decode($json);
         static::validate($data, new Collection(static::getConstraints()));

--- a/src/Metadata/TargetsMetadata.php
+++ b/src/Metadata/TargetsMetadata.php
@@ -27,7 +27,7 @@ class TargetsMetadata extends MetadataBase
      *
      * @var string
      */
-    private $role;
+    private ?string $role;
 
     /**
      * {@inheritdoc}
@@ -35,7 +35,7 @@ class TargetsMetadata extends MetadataBase
      * @param string|null $roleName
      *   The role name if not the same as the type.
      */
-    public static function createFromJson(string $json, string $roleName = null): MetadataBase
+    public static function createFromJson(string $json, string $roleName = null): static
     {
         $newMetadata = parent::createFromJson($json);
         $newMetadata->role = $roleName;

--- a/src/Metadata/Verifier/FileInfoVerifier.php
+++ b/src/Metadata/Verifier/FileInfoVerifier.php
@@ -11,14 +11,6 @@ use Tuf\Metadata\FileInfoMetadataBase;
 abstract class FileInfoVerifier extends VerifierBase
 {
     /**
-     * The trusted metadata, if any.
-     *
-     * @var \Tuf\Metadata\FileInfoMetadataBase
-     */
-    protected $trustedMetadata;
-
-
-    /**
      * Checks for rollback of files referenced in $untrustedMetadata.
      *
      * @param \Tuf\Metadata\FileInfoMetadataBase $untrustedMetadata

--- a/src/Metadata/Verifier/RootVerifier.php
+++ b/src/Metadata/Verifier/RootVerifier.php
@@ -12,13 +12,6 @@ use Tuf\Metadata\MetadataBase;
 class RootVerifier extends VerifierBase
 {
     /**
-     * The trusted root metadata.
-     *
-     * @var \Tuf\Metadata\RootMetadata
-     */
-    protected $trustedMetadata;
-
-    /**
      * {@inheritDoc}
      */
     public function verify(MetadataBase $untrustedMetadata): void

--- a/src/Metadata/Verifier/UniversalVerifier.php
+++ b/src/Metadata/Verifier/UniversalVerifier.php
@@ -15,27 +15,6 @@ use Tuf\Metadata\TimestampMetadata;
 class UniversalVerifier
 {
     /**
-     * The durable metadata storage.
-     *
-     * @var \Tuf\Metadata\StorageInterface
-     */
-    private StorageInterface $storage;
-
-    /**
-     * The signature verifier.
-     *
-     * @var SignatureVerifier
-     */
-    private $signatureVerifier;
-
-    /**
-     * The time beyond which untrusted metadata will be considered expired.
-     *
-     * @var \DateTimeImmutable
-     */
-    private $metadataExpiration;
-
-    /**
      * Factory constructor.
      *
      * @param \Tuf\Metadata\StorageInterface $storage
@@ -45,11 +24,8 @@ class UniversalVerifier
      * @param \DateTimeImmutable $metadataExpiration
      *   The time beyond which untrusted metadata will be considered expired.
      */
-    public function __construct(StorageInterface $storage, SignatureVerifier $signatureVerifier, \DateTimeImmutable $metadataExpiration)
+    public function __construct(private StorageInterface $storage, private SignatureVerifier $signatureVerifier, private \DateTimeImmutable $metadataExpiration)
     {
-        $this->storage = $storage;
-        $this->signatureVerifier = $signatureVerifier;
-        $this->metadataExpiration = $metadataExpiration;
     }
 
     /**

--- a/src/Metadata/Verifier/VerifierBase.php
+++ b/src/Metadata/Verifier/VerifierBase.php
@@ -14,27 +14,6 @@ use Tuf\Metadata\MetadataBase;
 abstract class VerifierBase
 {
     /**
-     * The trusted metadata, if any.
-     *
-     * @var \Tuf\Metadata\MetadataBase
-     */
-    protected $trustedMetadata;
-
-    /**
-     * The signature verifier.
-     *
-     * @var \Tuf\Client\SignatureVerifier
-     */
-    protected $signatureVerifier;
-
-    /**
-     * The time beyond which untrusted metadata will be considered expired.
-     *
-     * @var \DateTimeImmutable
-     */
-    protected $metadataExpiration;
-
-    /**
      * VerifierBase constructor.
      *
      * @param \Tuf\Client\SignatureVerifier $signatureVerifier
@@ -44,14 +23,11 @@ abstract class VerifierBase
      * @param \Tuf\Metadata\MetadataBase|null $trustedMetadata
      *   The trusted metadata, if any.
      */
-    public function __construct(SignatureVerifier $signatureVerifier, \DateTimeImmutable $metadataExpiration, ?MetadataBase $trustedMetadata = null)
+    public function __construct(protected SignatureVerifier $signatureVerifier, protected \DateTimeImmutable $metadataExpiration, protected ?MetadataBase $trustedMetadata = null)
     {
-        $this->signatureVerifier = $signatureVerifier;
-        $this->metadataExpiration = $metadataExpiration;
         if ($trustedMetadata) {
             $trustedMetadata->ensureIsTrusted();
         }
-        $this->trustedMetadata = $trustedMetadata;
     }
 
     /**

--- a/src/Role.php
+++ b/src/Role.php
@@ -12,27 +12,6 @@ class Role
     use ConstraintsTrait;
 
     /**
-     * The role name.
-     *
-     * @var string
-     */
-    protected $name;
-
-    /**
-     * The role threshold.
-     *
-     * @var int
-     */
-    protected $threshold;
-
-    /**
-     * The key IDs.
-     *
-     * @var array
-     */
-    protected $keyIds;
-
-    /**
      * Role constructor.
      *
      * @param string $name
@@ -42,11 +21,8 @@ class Role
      * @param array $keyIds
      *   The key IDs.
      */
-    protected function __construct(string $name, int $threshold, array $keyIds)
+    protected function __construct(protected string $name, protected int $threshold, protected array $keyIds)
     {
-        $this->name = $name;
-        $this->threshold = $threshold;
-        $this->keyIds = $keyIds;
     }
 
     /**


### PR DESCRIPTION
Because it's 2023, and our minimum supported PHP is 8.0. This removes a pile of annoying boilerplate, and anything that increases type safety is good.