### PR TITLE
Update TUF spec to v1.0.24

### DIFF
--- a/.github/workflows/specification-version-check.yml
+++ b/.github/workflows/specification-version-check.yml
@@ -11,4 +11,4 @@ jobs:
       issues: write
     uses: theupdateframework/specification/.github/workflows/check-latest-spec-version.yml@master
     with:
-      tuf-version: "v1.0.23" # Should be updated to the version the project supports either manually or extracted automatically. You can see how python-tuf did that as an example.
+      tuf-version: "v1.0.24" # Should be updated to the version the project supports either manually or extracted automatically. You can see how python-tuf did that as an example.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It should currently only be used for testing, development and feedback.
 PHP-TUF is a PHP implementation of [The Update Framework
 (TUF)](https://theupdateframework.io/) to provide signing and verification for
 secure PHP application updates. [Read the TUF
-specification](https://theupdateframework.github.io/specification/v1.0.23)
+specification](https://theupdateframework.github.io/specification/v1.0.24)
 for more information on how TUF is intended to work and the security it
 provides.
 
@@ -113,5 +113,5 @@ dependency information](DEPENDENCIES.md).
   * [Code Documentation: Main Index](https://github.com/theupdateframework/tuf/blob/develop/tuf/README.md)
   * [CLI](https://github.com/theupdateframework/tuf/blob/develop/docs/CLI.md)
   * [Python API Readme](https://github.com/theupdateframework/tuf/blob/develop/tuf/client/README.md)
-* [TUF Specification v1.0.23](https://theupdateframework.github.io/specification/v1.0.23)
+* [TUF Specification v1.0.24](https://theupdateframework.github.io/specification/v1.0.24)
 * [PIP + TUF Integration](https://www.python.org/dev/peps/pep-0458/)

--- a/src/Key.php
+++ b/src/Key.php
@@ -38,7 +38,7 @@ final class Key
      *
      * @return static
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.23#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.24#document-formats
      */
     public static function createFromMetadata(array $keyInfo): self
     {
@@ -81,7 +81,7 @@ final class Key
      * @return string
      *     The key ID in hex format for the key metadata hashed using sha256.
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.23#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.24#document-formats
      *
      * @todo https://github.com/php-tuf/php-tuf/issues/56
      */

--- a/src/KeyDB.php
+++ b/src/KeyDB.php
@@ -42,7 +42,7 @@ class KeyDB
      * @throws \Tuf\Exception\InvalidKeyException
      *   Thrown if an unsupported or invalid key exists in the metadata.
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.23#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.24#document-formats
      */
     public static function createFromRootMetadata(RootMetadata $rootMetadata, bool $allowUntrustedAccess = false): KeyDB
     {
@@ -77,7 +77,7 @@ class KeyDB
      *
      * @return void
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.23#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.24#document-formats
      */
     public function addKey(string $keyId, Key $key): void
     {
@@ -107,7 +107,7 @@ class KeyDB
      * @throws \Tuf\Exception\NotFoundException
      *     Thrown if the key ID is not found in the keydb database.
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.23#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.24#document-formats
      */
     public function getKey(string $keyId): Key
     {

--- a/src/Metadata/TargetsMetadata.php
+++ b/src/Metadata/TargetsMetadata.php
@@ -110,13 +110,13 @@ class TargetsMetadata extends MetadataBase
                                 new NotBlank(),
                                 new Type('string'),
                             ],
-                            'paths' => [
+                            'paths' => new Optional([
                                 new Type('array'),
                                 new All([
                                     new Type('string'),
                                     new NotBlank(),
                                 ]),
-                            ],
+                            ]),
                             'terminating' => [
                                 new Type('boolean'),
                             ],

--- a/src/Role.php
+++ b/src/Role.php
@@ -35,7 +35,7 @@ class Role
      *
      * @return static
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.23#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.24#document-formats
      */
     public static function createFromMetadata(array $roleInfo, string $name): Role
     {

--- a/src/RoleDB.php
+++ b/src/RoleDB.php
@@ -34,7 +34,7 @@ class RoleDB
      * @throws \Exception
      *     Thrown if a threshold value in the metadata is not valid.
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.23#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.24#document-formats
      */
     public static function createFromRootMetadata(RootMetadata $rootMetadata, bool $allowUntrustedAccess = false): RoleDB
     {
@@ -101,7 +101,7 @@ class RoleDB
      * @throws \Tuf\Exception\NotFoundException
      *     Thrown if the role does not exist.
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.23#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.24#document-formats
      */
     public function getRole(string $roleName): Role
     {

--- a/tests/Metadata/TargetsMetadataTest.php
+++ b/tests/Metadata/TargetsMetadataTest.php
@@ -97,7 +97,6 @@ class TargetsMetadataTest extends MetadataBaseTest
         $data[] = ['signed:delegations:roles'];
         $data[] = ['signed:delegations:roles:0:keyids'];
         $data[] = ['signed:delegations:roles:0:name'];
-        $data[] = ['signed:delegations:roles:0:paths'];
         $data[] = ['signed:delegations:roles:0:terminating'];
         $data[] = ['signed:delegations:roles:0:threshold'];
         $target = $this->getFixtureNestedArrayFirstKey($this->validJson, ['signed', 'targets']);
@@ -133,6 +132,10 @@ class TargetsMetadataTest extends MetadataBaseTest
                 'keys' => [],
                 'roles' => [],
             ],
+        ];
+        $data[] = [
+            'signed:delegations:roles:0:paths',
+            ['delegated/path']
         ];
         return $data;
     }

--- a/tests/Metadata/TargetsMetadataTest.php
+++ b/tests/Metadata/TargetsMetadataTest.php
@@ -135,7 +135,7 @@ class TargetsMetadataTest extends MetadataBaseTest
         ];
         $data[] = [
             'signed:delegations:roles:0:paths',
-            ['delegated/path']
+            ['delegated/path'],
         ];
         return $data;
     }


### PR DESCRIPTION
See https://github.com/theupdateframework/specification/compare/v1.0.23...v1.0.24

Three relevant bits here:

> An OPTIONAL boolean indicating whether the repository supports consistent snapshots.

This is already optional, and tested in `\Tuf\Tests\Metadata\RootMetadataTest::providerOptionalFields()`.

> DELEGATIONS is an OPTIONAL object

This is also already the case, and tested by `\Tuf\Tests\Metadata\TargetsMetadataTest::providerOptionalFields()`.

> The "path_hash_prefixes" and "paths" attributes are OPTIONAL

Ah, _this_ we needed to change. I did that, and added test coverage in TargetsMetadataTest. I confirmed that removing the `Optional` constraint from `paths` causes the test to fail.