### PR TITLE
Update TUF spec to v1.0.26

### DIFF
--- a/.github/workflows/specification-version-check.yml
+++ b/.github/workflows/specification-version-check.yml
@@ -11,4 +11,4 @@ jobs:
       issues: write
     uses: theupdateframework/specification/.github/workflows/check-latest-spec-version.yml@master
     with:
-      tuf-version: "v1.0.25" # Should be updated to the version the project supports either manually or extracted automatically. You can see how python-tuf did that as an example.
+      tuf-version: "v1.0.26" # Should be updated to the version the project supports either manually or extracted automatically. You can see how python-tuf did that as an example.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It should currently only be used for testing, development and feedback.
 PHP-TUF is a PHP implementation of [The Update Framework
 (TUF)](https://theupdateframework.io/) to provide signing and verification for
 secure PHP application updates. [Read the TUF
-specification](https://theupdateframework.github.io/specification/v1.0.25)
+specification](https://theupdateframework.github.io/specification/v1.0.26)
 for more information on how TUF is intended to work and the security it
 provides.
 
@@ -113,5 +113,5 @@ dependency information](DEPENDENCIES.md).
   * [Code Documentation: Main Index](https://github.com/theupdateframework/tuf/blob/develop/tuf/README.md)
   * [CLI](https://github.com/theupdateframework/tuf/blob/develop/docs/CLI.md)
   * [Python API Readme](https://github.com/theupdateframework/tuf/blob/develop/tuf/client/README.md)
-* [TUF Specification v1.0.25](https://theupdateframework.github.io/specification/v1.0.25)
+* [TUF Specification v1.0.26](https://theupdateframework.github.io/specification/v1.0.26)
 * [PIP + TUF Integration](https://www.python.org/dev/peps/pep-0458/)

--- a/src/Key.php
+++ b/src/Key.php
@@ -38,7 +38,7 @@ final class Key
      *
      * @return static
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.25#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.26#document-formats
      */
     public static function createFromMetadata(array $keyInfo): self
     {
@@ -81,7 +81,7 @@ final class Key
      * @return string
      *     The key ID in hex format for the key metadata hashed using sha256.
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.25#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.26#document-formats
      *
      * @todo https://github.com/php-tuf/php-tuf/issues/56
      */

--- a/src/KeyDB.php
+++ b/src/KeyDB.php
@@ -42,7 +42,7 @@ class KeyDB
      * @throws \Tuf\Exception\InvalidKeyException
      *   Thrown if an unsupported or invalid key exists in the metadata.
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.25#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.26#document-formats
      */
     public static function createFromRootMetadata(RootMetadata $rootMetadata, bool $allowUntrustedAccess = false): KeyDB
     {
@@ -77,7 +77,7 @@ class KeyDB
      *
      * @return void
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.25#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.26#document-formats
      */
     public function addKey(string $keyId, Key $key): void
     {
@@ -107,7 +107,7 @@ class KeyDB
      * @throws \Tuf\Exception\NotFoundException
      *     Thrown if the key ID is not found in the keydb database.
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.25#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.26#document-formats
      */
     public function getKey(string $keyId): Key
     {

--- a/src/Role.php
+++ b/src/Role.php
@@ -35,7 +35,7 @@ class Role
      *
      * @return static
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.25#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.26#document-formats
      */
     public static function createFromMetadata(array $roleInfo, string $name): Role
     {

--- a/src/RoleDB.php
+++ b/src/RoleDB.php
@@ -34,7 +34,7 @@ class RoleDB
      * @throws \Exception
      *     Thrown if a threshold value in the metadata is not valid.
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.25#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.26#document-formats
      */
     public static function createFromRootMetadata(RootMetadata $rootMetadata, bool $allowUntrustedAccess = false): RoleDB
     {
@@ -101,7 +101,7 @@ class RoleDB
      * @throws \Tuf\Exception\NotFoundException
      *     Thrown if the role does not exist.
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.25#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.26#document-formats
      */
     public function getRole(string $roleName): Role
     {


### PR DESCRIPTION
The diff: https://github.com/theupdateframework/specification/compare/v1.0.25...v1.0.26

Although this looks intimidating, this update is all about the _server_ side and how it writes metadata. I don't think there are any changes, per se; it's just that the language is stricter, clearer, and more formal. There are some clarifications. We're already consistent with the described behavior.