### PR TITLE
Use validation constraints to check key type

### DIFF
--- a/src/KeyDB.php
+++ b/src/KeyDB.php
@@ -56,18 +56,6 @@ class KeyDB
     }
 
     /**
-     * Gets the supported encryption key types.
-     *
-     * @return string[]
-     *     An array of supported encryption key type names (e.g. 'ed25519').
-     */
-    public static function getSupportedKeyTypes(): array
-    {
-        return ['ed25519'];
-    }
-
-
-    /**
      * Adds key metadata to the key database while avoiding duplicates.
      *
      * @param string $keyId
@@ -81,12 +69,6 @@ class KeyDB
      */
     public function addKey(string $keyId, Key $key): void
     {
-        $keyType = $key->getType();
-        if (! in_array($keyType, self::getSupportedKeyTypes(), true)) {
-            // @todo Convert this to a log line as per Python.
-            // https://github.com/php-tuf/php-tuf/issues/160
-            throw new InvalidKeyException("Root metadata file contains an unsupported key type: '$keyType'");
-        }
         // Per TUF specification 4.3, Clients MUST calculate each KEYID to
         // verify this is correct for the associated key.
         if ($keyId !== $key->getComputedKeyId()) {

--- a/src/Metadata/ConstraintsTrait.php
+++ b/src/Metadata/ConstraintsTrait.php
@@ -8,6 +8,7 @@ use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\Count;
 use Symfony\Component\Validator\Constraints\EqualTo;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
+use Symfony\Component\Validator\Constraints\IdenticalTo;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Optional;
 use Symfony\Component\Validator\Constraints\Type;
@@ -139,7 +140,7 @@ trait ConstraintsTrait
             ]),
             'keytype' => [
                 new Type('string'),
-                new NotBlank(),
+                new IdenticalTo('ed25519'),
             ],
             'keyval' => [
                 new Type('array'),

--- a/tests/KeyDBTest.php
+++ b/tests/KeyDBTest.php
@@ -4,8 +4,6 @@ namespace Tuf\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
-use Tuf\Exception\InvalidKeyException;
-use Tuf\Key;
 use Tuf\KeyDB;
 use Tuf\Metadata\RootMetadata;
 use Tuf\Tests\TestHelpers\FixturesTrait;
@@ -43,23 +41,5 @@ class KeyDBTest extends TestCase
         self::assertSame($key->getPublic(), $retrievedKey->getPublic());
         self::assertSame($key->getType(), $retrievedKey->getType());
         self::assertSame($key->getComputedKeyId(), $retrievedKey->getComputedKeyId());
-    }
-
-    public function testUnsupportedKeyType(): void
-    {
-        $key = [
-            'keytype' => 'unsupported',
-            'scheme' => 'ed25519',
-            'keyval' => ['public' => 'this is the public key'],
-        ];
-
-        $rootMetadata = $this->prophesize(RootMetadata::class);
-        $rootMetadata->getKeys(false)->willReturn([
-            'unsupported_key' => Key::createFromMetadata($key),
-        ]);
-
-        $this->expectException(InvalidKeyException::class);
-        $this->expectExceptionMessage("Root metadata file contains an unsupported key type: 'unsupported'");
-        KeyDB::createFromRootMetadata($rootMetadata->reveal());
     }
 }

--- a/tests/Metadata/RootMetadataTest.php
+++ b/tests/Metadata/RootMetadataTest.php
@@ -209,4 +209,16 @@ class RootMetadataTest extends MetadataBaseTest
         self::expectExceptionMessageMatches("/$expectedMessage/s");
         static::callCreateFromJson(json_encode($data));
     }
+
+    public function testInvalidKeyType(): void
+    {
+        $metadata = json_decode($this->clientStorage->read($this->validJson), true);
+        $keyId = key($metadata['signed']['keys']);
+        $metadata['signed']['keys'][$keyId]['keytype'] = 'invalid key type';
+        $expectedMessage = preg_quote("Array[signed][keys][$keyId][keytype]", '/');
+        $expectedMessage .= ".*This value should be identical to string \"ed25519\"";
+        $this->expectException(MetadataException::class);
+        $this->expectExceptionMessageMatches("/$expectedMessage/s");
+        static::callCreateFromJson(json_encode($metadata));
+    }
 }

--- a/tests/Unit/KeyTest.php
+++ b/tests/Unit/KeyTest.php
@@ -21,17 +21,17 @@ class KeyTest extends TestCase
     public function testCreateFromMetadata(array $data): void
     {
         $data += [
-            'keytype' => 'ed11111',
+            'keytype' => 'ed25519',
             'scheme' => 'scheme-ed11111',
             'keyval' => ['public' => '12345'],
         ];
         $key = Key::createFromMetadata($data);
         self::assertInstanceOf(Key::class, $key);
-        self::assertSame('ed11111', $key->getType());
+        self::assertSame('ed25519', $key->getType());
         self::assertSame('12345', $key->getPublic());
         $keySortedCanonicalStruct = [
             'keyid_hash_algorithms' => ['sha256', 'sha512'],
-            'keytype' => 'ed11111',
+            'keytype' => 'ed25519',
             'keyval' => ['public' => '12345'],
             'scheme' => 'scheme-ed11111',
         ];


### PR DESCRIPTION
This is some clean-up in the name of brevity. Right now, we do a specific check in KeyDB::addKey() that the incoming key is of a supported type. Given how KeyDB is created (basically it's just pulling directly from some root metadata), there is no reason why we shouldn't just use a validation constraint for this. It's simpler and lets us keep related validation logic in one place.