### PR TITLE
Use sodium_hex2bin

### DIFF
--- a/src/Client/SignatureVerifier.php
+++ b/src/Client/SignatureVerifier.php
@@ -98,8 +98,8 @@ final class SignatureVerifier
 
         // Encode the pubkey and signature, and check that the signature is
         // valid for the given data and pubkey.
-        $pubkeyBytes = hex2bin($pubkey);
-        $sigBytes = hex2bin($signatureMeta['sig']);
+        $pubkeyBytes = \sodium_hex2bin($pubkey);
+        $sigBytes = \sodium_hex2bin($signatureMeta['sig']);
         return \sodium_crypto_sign_verify_detached($sigBytes, $bytes, $pubkeyBytes);
     }
 


### PR DESCRIPTION
In SignatureVerifier, we currently call PHP's `hex2bin()`. According to [PHP's documentation](https://www.php.net/sodium_hex2bin), this function is susceptible to side-channel attacks, whereas `sodium_hex2bin` isn't. Since we already use sodium functions, we should use `sodium_hex2bin` here.