### PR TITLE
MetadataBase::getExpires() should return a DateTimeImmutable object

### DIFF
--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -14,6 +14,7 @@ use Symfony\Component\Validator\Constraints\Required;
 use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Tuf\CanonicalJsonTrait;
+use Tuf\Exception\FormatException;
 
 /**
  * Base class for metadata.
@@ -208,14 +209,18 @@ abstract class MetadataBase
     }
 
     /**
-     * Get the expires date string.
+     * Get the expiration date of this metadata.
      *
-     * @return string
-     *   The date string.
+     * @return \DateTimeImmutable
+     *   The date and time that this metadata expires.
+     *
+     * @throws \Tuf\Exception\FormatException
+     *   If the expiration date and time cannot be parsed.
      */
-    public function getExpires(): string
+    public function getExpires(): \DateTimeImmutable
     {
-        return $this->getSigned()['expires'];
+        $timestamp = $this->getSigned()['expires'];
+        return \DateTimeImmutable::createFromFormat("Y-m-d\TH:i:sT", $timestamp) ?: throw new FormatException($timestamp, "Could not be interpreted as a DateTime");
     }
 
     /**

--- a/src/Metadata/Verifier/VerifierBase.php
+++ b/src/Metadata/Verifier/VerifierBase.php
@@ -3,7 +3,6 @@
 namespace Tuf\Metadata\Verifier;
 
 use Tuf\Client\SignatureVerifier;
-use Tuf\Exception\FormatException;
 use Tuf\Exception\Attack\FreezeAttackException;
 use Tuf\Exception\Attack\RollbackAttackException;
 use Tuf\Metadata\MetadataBase;
@@ -80,37 +79,15 @@ abstract class VerifierBase
      * @param \DateTimeImmutable $expiration
      *     The metadata expiration.
      *
-     * @return void
-     *
-     * @throws \Tuf\Exception\Attack\FreezeAttackException Thrown if a potential freeze attack is detected.
+     * @throws \Tuf\Exception\Attack\FreezeAttackException
+     *   Thrown if a potential freeze attack is detected.
      */
     protected static function checkFreezeAttack(MetadataBase $metadata, \DateTimeImmutable $expiration): void
     {
-        $metadataExpiration = static::metadataTimestampToDatetime($metadata->getExpires());
+        $metadataExpiration = $metadata->getExpires();
         if ($metadataExpiration < $expiration) {
             $format = "Remote %s metadata expired on %s";
             throw new FreezeAttackException(sprintf($format, $metadata->getRole(), $metadataExpiration->format('c')));
         }
-    }
-
-    /**
-     * Converts a metadata timestamp string into an immutable DateTime object.
-     *
-     * @param string $timestamp
-     *     The timestamp string in the metadata.
-     *
-     * @return \DateTimeImmutable
-     *     An immutable DateTime object for the given timestamp.
-     *
-     * @throws FormatException
-     *     Thrown if the timestamp string format is not valid.
-     */
-    protected static function metadataTimestampToDateTime(string $timestamp): \DateTimeImmutable
-    {
-        $dateTime = \DateTimeImmutable::createFromFormat("Y-m-d\TH:i:sT", $timestamp);
-        if ($dateTime === false) {
-            throw new FormatException($timestamp, "Could not be interpreted as a DateTime");
-        }
-        return $dateTime;
     }
 }

--- a/tests/Unit/Client/VerifierTest.php
+++ b/tests/Unit/Client/VerifierTest.php
@@ -142,11 +142,13 @@ class VerifierTest extends TestCase
         // We test lack of an exception in the positive test case.
         $this->expectNotToPerformAssertions();
 
+        $dateFormat = "Y-m-d\TH:i:sT";
         $signedMetadata = $this->getMockBuilder(MetadataBase::class)->disableOriginalConstructor()->getMock();
         $signedMetadata->expects(self::any())->method('getType')->willReturn('any');
-        $signedMetadata->expects(self::any())->method('getExpires')->willReturn('1970-01-01T00:00:01Z');
+        $expiration = \DateTimeImmutable::createFromFormat($dateFormat, '1970-01-01T00:00:01Z');
+        $signedMetadata->expects(self::any())->method('getExpires')->willReturn($expiration);
         $nowString = '1970-01-01T00:00:00Z';
-        $now = \DateTimeImmutable::createFromFormat("Y-m-d\TH:i:sT", $nowString);
+        $now = \DateTimeImmutable::createFromFormat($dateFormat, $nowString);
 
         $method = new \ReflectionMethod(VerifierBase::class, 'checkFreezeAttack');
         $method->setAccessible(true);
@@ -156,7 +158,7 @@ class VerifierTest extends TestCase
         $method->invoke(null, $signedMetadata, $now);
 
         // No exception should be thrown exactly at expiration time.
-        $signedMetadata->expects(self::any())->method('getExpires')->willReturn($nowString);
+        $signedMetadata->expects(self::any())->method('getExpires')->willReturn($now);
         $method->invoke(null, $signedMetadata, $now);
     }
 
@@ -174,11 +176,13 @@ class VerifierTest extends TestCase
     {
         $this->expectException('\Tuf\Exception\Attack\FreezeAttackException');
 
+        $dateFormat = "Y-m-d\TH:i:sT";
         $signedMetadata = $this->getMockBuilder(MetadataBase::class)->disableOriginalConstructor()->getMock();
         $signedMetadata->expects(self::any())->method('getType')->willReturn('any');
-        $signedMetadata->expects(self::any())->method('getExpires')->willReturn('1970-01-01T00:00:00Z');
+        $expiration = \DateTimeImmutable::createFromFormat($dateFormat, '1970-01-01T00:00:00Z');
+        $signedMetadata->expects(self::any())->method('getExpires')->willReturn($expiration);
         // 1 second later.
-        $now = \DateTimeImmutable::createFromFormat("Y-m-d\TH:i:sT", '1970-01-01T00:00:01Z');
+        $now = \DateTimeImmutable::createFromFormat($dateFormat, '1970-01-01T00:00:01Z');
 
         $method = new \ReflectionMethod(VerifierBase::class, 'checkFreezeAttack');
         $method->setAccessible(true);


### PR DESCRIPTION
Right now, when checking for freeze attacks, we call MetadataBase::getExpires() and convert it to a DateTimeImmutable object. There is, as far as I can tell, no reason not to just, like, return a \DateTimeImmutable from `MetadataBase::getExpires()`. It makes for a simpler API and removes the need for a special conversion method in `VerifierBase`.