### PR TITLE
Allow DelegatedRole to validate and carry path_hash_prefixes

### DIFF
--- a/src/DelegatedRole.php
+++ b/src/DelegatedRole.php
@@ -53,8 +53,8 @@ class DelegatedRole extends Role
             'paths' => new Optional([
                 new Type('array'),
                 new All([
-                   new Type('string'),
-                   new NotBlank(),
+                    new Type('string'),
+                    new NotBlank(),
                 ]),
             ]),
             'path_hash_prefixes' => new Optional([

--- a/src/DelegatedRole.php
+++ b/src/DelegatedRole.php
@@ -50,6 +50,8 @@ class DelegatedRole extends Role
                 ]
             ),
             'terminating' => new Required(new Type('boolean')),
+            // `paths` is mutually exclusive with `path_hash_prefixes`.
+            // @see ::validate()
             'paths' => new Optional([
                 new Type('array'),
                 new All([

--- a/src/DelegatedRole.php
+++ b/src/DelegatedRole.php
@@ -4,6 +4,7 @@
 namespace Tuf;
 
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Optional;
 use Symfony\Component\Validator\Constraints\Required;
 use Symfony\Component\Validator\Constraints\Type;
 
@@ -26,10 +27,11 @@ class DelegatedRole extends Role
      * @param string $name
      * @param int $threshold
      * @param array $keyIds
-     * @param array $paths
+     * @param array|null $paths
+     * @param array|null $pathHashPrefixes
      * @param bool $terminating
      */
-    private function __construct(string $name, int $threshold, array $keyIds, protected array $paths, protected bool $terminating)
+    private function __construct(string $name, int $threshold, array $keyIds, protected ?array $paths, protected ?array $pathHashPrefixes, protected bool $terminating)
     {
         parent::__construct($name, $threshold, $keyIds);
     }
@@ -45,14 +47,16 @@ class DelegatedRole extends Role
                 ]
             ),
             'terminating' => new Required(new Type('boolean')),
-            'paths' => new Required(new Type('array')),
+            'paths' => new Optional(new Type('array')),
+            'path_hash_prefixes' => new Optional(new Type('array')),
         ];
         static::validate($roleInfo, $roleConstraints);
         return new static(
             $roleInfo['name'],
             $roleInfo['threshold'],
             $roleInfo['keyids'],
-            $roleInfo['paths'],
+            $roleInfo['paths'] ?? null,
+            $roleInfo['path_hash_prefixes'] ?? null,
             $roleInfo['terminating']
         );
     }

--- a/src/DelegatedRole.php
+++ b/src/DelegatedRole.php
@@ -3,6 +3,7 @@
 
 namespace Tuf;
 
+use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Optional;
@@ -49,8 +50,20 @@ class DelegatedRole extends Role
                 ]
             ),
             'terminating' => new Required(new Type('boolean')),
-            'paths' => new Optional(new Type('array')),
-            'path_hash_prefixes' => new Optional(new Type('array')),
+            'paths' => new Optional([
+                new Type('array'),
+                new All([
+                   new Type('string'),
+                   new NotBlank(),
+                ]),
+            ]),
+            'path_hash_prefixes' => new Optional([
+                new Type('array'),
+                new All([
+                    new Type('string'),
+                    new NotBlank(),
+                ]),
+            ]),
         ];
         static::validate($roleInfo, $roleConstraints);
         return new static(

--- a/src/DelegatedRole.php
+++ b/src/DelegatedRole.php
@@ -3,10 +3,12 @@
 
 namespace Tuf;
 
+use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Optional;
 use Symfony\Component\Validator\Constraints\Required;
 use Symfony\Component\Validator\Constraints\Type;
+use Tuf\Exception\MetadataException;
 
 /**
  * Class that represents a Delegated TUF role.
@@ -59,6 +61,20 @@ class DelegatedRole extends Role
             $roleInfo['path_hash_prefixes'] ?? null,
             $roleInfo['terminating']
         );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected static function validate(array $data, Collection $constraints): void
+    {
+        parent::validate($data, $constraints);
+
+        // Either `paths` or `path_hash_prefixes` MUST be specified, but not
+        // both.
+        if (!(array_key_exists('paths', $data) xor array_key_exists('path_hash_prefixes', $data))) {
+            throw new MetadataException('Either paths or path_hash_prefixes must be specified, but not both.');
+        }
     }
 
     /**

--- a/src/Metadata/TargetsMetadata.php
+++ b/src/Metadata/TargetsMetadata.php
@@ -116,6 +116,13 @@ class TargetsMetadata extends MetadataBase
                                     new NotBlank(),
                                 ]),
                             ]),
+                            'path_hash_prefixes' => new Optional([
+                                new Type('array'),
+                                new All([
+                                    new Type('string'),
+                                    new NotBlank(),
+                                ]),
+                            ]),
                             'terminating' => [
                                 new Type('boolean'),
                             ],

--- a/tests/Metadata/TargetsMetadataTest.php
+++ b/tests/Metadata/TargetsMetadataTest.php
@@ -113,6 +113,10 @@ class TargetsMetadataTest extends MetadataBaseTest
         $data[] = ["signed:targets:$target:hashes", 'array'];
         $data[] = ["signed:targets:$target:length", 'int'];
         $data[] = ["signed:targets:$target:custom", 'array'];
+
+        $role = $this->getFixtureNestedArrayFirstKey($this->validJson, ['signed', 'delegations', 'roles']);
+        $data[] = ["signed:delegations:roles:$role:paths", 'array'];
+        $data[] = ["signed:delegations:roles:$role:path_hash_prefixes", 'array'];
         return $data;
     }
 

--- a/tests/Unit/DelegatedRoleTest.php
+++ b/tests/Unit/DelegatedRoleTest.php
@@ -3,6 +3,7 @@
 namespace Tuf\Tests\Unit;
 
 use Tuf\DelegatedRole;
+use Tuf\Exception\MetadataException;
 use Tuf\Role;
 
 /**
@@ -97,5 +98,62 @@ class DelegatedRoleTest extends RoleTest
             ],
         ];
         return DelegatedRole::createFromMetadata($data);
+    }
+
+    public function testNoPathsOrPrefixes(): void
+    {
+        $this->expectException(MetadataException::class);
+        $this->expectExceptionMessage('Either paths or path_hash_prefixes must be specified, but not both.');
+
+        $this->createTestRole([
+            'name' => 'my_role',
+            'threshold' => 1000,
+            'keyids' => [
+                'good_key_1',
+                'good_key_2',
+            ],
+            'terminating' => false,
+        ]);
+    }
+
+    public function testPathsAndPrefixes(): void
+    {
+        $this->expectException(MetadataException::class);
+        $this->expectExceptionMessage('Either paths or path_hash_prefixes must be specified, but not both.');
+
+        $this->createTestRole([
+            'name' => 'my_role',
+            'threshold' => 1000,
+            'keyids' => [
+                'good_key_1',
+                'good_key_2',
+            ],
+            'terminating' => false,
+            'paths' => [],
+            'path_hash_prefixes' => [],
+        ]);
+    }
+
+    /**
+     * @param string $key
+     *
+     * @testWith ["paths"]
+     *   ["path_hash_prefixes"]
+     */
+    public function testPathsAndPrefixesMustBeArrays(string $key): void
+    {
+        $this->expectException(MetadataException::class);
+        $this->expectExceptionMessageMatches("/Array\[$key\]:\s*This value should be of type array\./");
+
+        $this->createTestRole([
+            'name' => 'my_role',
+            'threshold' => 1000,
+            'keyids' => [
+                'good_key_1',
+                'good_key_2',
+            ],
+            'terminating' => false,
+            $key => 'Not an array!',
+        ]);
     }
 }

--- a/tests/Unit/DelegatedRoleTest.php
+++ b/tests/Unit/DelegatedRoleTest.php
@@ -135,15 +135,20 @@ class DelegatedRoleTest extends RoleTest
     }
 
     /**
-     * @param string $key
-     *
-     * @testWith ["paths"]
-     *   ["path_hash_prefixes"]
+     * @testWith ["paths", "Not an array!", ["paths"], "This value should be of type array."]
+     *   ["paths", [""], ["paths", 0], "This value should not be blank."]
+     *   ["paths", [38], ["paths", 0], "This value should be of type string."]
+     *   ["path_hash_prefixes", "Not an array!", ["path_hash_prefixes"], "This value should be of type array."]
+     *   ["path_hash_prefixes", [""], ["path_hash_prefixes", 0], "This value should not be blank."]
+     *   ["path_hash_prefixes", [38], ["path_hash_prefixes", 0], "This value should be of type string."]
      */
-    public function testPathsAndPrefixesMustBeArrays(string $key): void
+    public function testPathsAndPrefixesMustBeArrays(string $key, mixed $value, array $propertyPath, string $expectedError): void
     {
+        $propertyPath = preg_quote('[' . implode('][', $propertyPath) . ']');
+        $expectedError = preg_quote($expectedError);
+
         $this->expectException(MetadataException::class);
-        $this->expectExceptionMessageMatches("/Array\[$key\]:\s*This value should be of type array\./");
+        $this->expectExceptionMessageMatches("/Array$propertyPath:\s*$expectedError/");
 
         $this->createTestRole([
             'name' => 'my_role',
@@ -153,7 +158,7 @@ class DelegatedRoleTest extends RoleTest
                 'good_key_2',
             ],
             'terminating' => false,
-            $key => 'Not an array!',
+            $key => $value,
         ]);
     }
 }

--- a/tests/Unit/DelegatedRoleTest.php
+++ b/tests/Unit/DelegatedRoleTest.php
@@ -28,24 +28,6 @@ class DelegatedRoleTest extends RoleTest
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function providerInvalidMetadata(): array
-    {
-        return [
-            'nothing' => [[]],
-            'no paths' => [
-                [
-                    'name' => 'a role',
-                    'threshold' => 1,
-                    'keyids' => ['good_key'],
-                    'terminating' => false,
-                ],
-            ],
-        ];
-    }
-
-    /**
      * @covers ::matchesPath
      *
      * @param string $target


### PR DESCRIPTION
Part 2 of fixing #191.

This adds support for `path_hash_prefixes` to the DelegatedRole metadata object, and ensures it's mutually exclusive with `paths`.