### PR TITLE
Indexed arrays with >= 10 items are incorrectly canonicalized

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "ext-json": "*",
         "paragonie/sodium_compat": "^1.13",
         "symfony/validator": "^4.4 || ^5 || ^6",
-        "guzzlehttp/psr7": "^2.4"
+        "guzzlehttp/psr7": "^2.4",
+        "symfony/polyfill-php81": "^1.27"
     },
     "suggest": {
         "ext-sodium": "Provides faster verification of updates"

--- a/src/CanonicalJsonTrait.php
+++ b/src/CanonicalJsonTrait.php
@@ -26,7 +26,11 @@ trait CanonicalJsonTrait
      */
     protected static function encodeJson(array $data): string
     {
-        static::sortKeys($data);
+        // If the array is numerically indexed, the keys are already sorted by
+        // definition.
+        if (!array_is_list($data)) {
+            static::sortKeys($data);
+        }
         return json_encode($data, JSON_UNESCAPED_SLASHES);
     }
 

--- a/tests/Unit/CanonicalJsonTraitTest.php
+++ b/tests/Unit/CanonicalJsonTraitTest.php
@@ -25,6 +25,17 @@ class CanonicalJsonTraitTest extends TestCase
     }
 
     /**
+     * Indexed arrays with >= 10 items should not be changed.
+     */
+    public function testIndexedArraysAreNotChanged(): void
+    {
+        $indexed = array_fill(0, 20, 'Hello!');
+        $this->assertTrue(array_is_list($indexed));
+        $canonicalized = static::encodeJson($indexed);
+        $this->assertSame($indexed, static::decodeJson($canonicalized));
+    }
+
+    /**
      * @covers ::encodeJson
      */
     public function testSlashEscaping(): void


### PR DESCRIPTION
These arrays (which are detectable with PHP 8.1's `array_is_list()` function) should not have their keys sorted -- by definition, their keys are already sorted. But we sort them anyway, which results in them being incorrectly canonicalized, and thus causing false negatives during signature verification.

We should use Symfony's PHP 8.1 polyfill to bring in `array_is_list()`, and then ensure we don't sort the keys of indexed arrays when canonicalizing.

This bug manifests on arrays with more than 10 items, because keys like `10`, `11`, and so forth get put after 1, but before 2. So you end up with keys in the wrong order: `1, 10, 11, 2`.