### PR TITLE
Revert "Indexed arrays with >= 10 items are incorrectly canonicalized"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
         "ext-json": "*",
         "paragonie/sodium_compat": "^1.13",
         "symfony/validator": "^4.4 || ^5 || ^6",
-        "guzzlehttp/psr7": "^2.4",
-        "symfony/polyfill-php81": "^1.27"
+        "guzzlehttp/psr7": "^2.4"
     },
     "suggest": {
         "ext-sodium": "Provides faster verification of updates"

--- a/src/CanonicalJsonTrait.php
+++ b/src/CanonicalJsonTrait.php
@@ -26,11 +26,7 @@ trait CanonicalJsonTrait
      */
     protected static function encodeJson(array $data): string
     {
-        // If the array is numerically indexed, the keys are already sorted by
-        // definition.
-        if (!array_is_list($data)) {
-            static::sortKeys($data);
-        }
+        static::sortKeys($data);
         return json_encode($data, JSON_UNESCAPED_SLASHES);
     }
 

--- a/tests/Unit/CanonicalJsonTraitTest.php
+++ b/tests/Unit/CanonicalJsonTraitTest.php
@@ -25,17 +25,6 @@ class CanonicalJsonTraitTest extends TestCase
     }
 
     /**
-     * Indexed arrays with >= 10 items should not be changed.
-     */
-    public function testIndexedArraysAreNotChanged(): void
-    {
-        $indexed = array_fill(0, 20, 'Hello!');
-        $this->assertTrue(array_is_list($indexed));
-        $canonicalized = static::encodeJson($indexed);
-        $this->assertSame($indexed, static::decodeJson($canonicalized));
-    }
-
-    /**
      * @covers ::encodeJson
      */
     public function testSlashEscaping(): void


### PR DESCRIPTION
Reverts php-tuf/php-tuf#340

This was done incorrectly, it turns out.

The check has to be inside `sortKeys()`, since it needs to be done at _every_ level of the array, not just the top level.