### PR TITLE
Ensure indexed arrays are not sorted alphabetically at any level

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "ext-json": "*",
         "paragonie/sodium_compat": "^1.13",
         "symfony/validator": "^4.4 || ^5 || ^6",
-        "guzzlehttp/psr7": "^2.4"
+        "guzzlehttp/psr7": "^2.4",
+        "symfony/polyfill-php81": "^1.27"
     },
     "suggest": {
         "ext-sodium": "Provides faster verification of updates"

--- a/src/CanonicalJsonTrait.php
+++ b/src/CanonicalJsonTrait.php
@@ -26,7 +26,11 @@ trait CanonicalJsonTrait
      */
     protected static function encodeJson(array $data): string
     {
-        static::sortKeys($data);
+        // If the array is numerically indexed, the keys are already sorted by
+        // definition.
+        if (!array_is_list($data)) {
+            static::sortKeys($data);
+        }
         return json_encode($data, JSON_UNESCAPED_SLASHES);
     }
 

--- a/src/CanonicalJsonTrait.php
+++ b/src/CanonicalJsonTrait.php
@@ -26,11 +26,7 @@ trait CanonicalJsonTrait
      */
     protected static function encodeJson(array $data): string
     {
-        // If the array is numerically indexed, the keys are already sorted by
-        // definition.
-        if (!array_is_list($data)) {
-            static::sortKeys($data);
-        }
+        static::sortKeys($data);
         return json_encode($data, JSON_UNESCAPED_SLASHES);
     }
 
@@ -59,6 +55,12 @@ trait CanonicalJsonTrait
      */
     private static function sortKeys(array &$data): void
     {
+        // If $data is numerically indexed, the keys are already sorted, by
+        // definition.
+        if (array_is_list($data)) {
+            return;
+        }
+
         if (!ksort($data, SORT_STRING)) {
             throw new \RuntimeException("Failure sorting keys. Canonicalization is not possible.");
         }

--- a/tests/Unit/CanonicalJsonTraitTest.php
+++ b/tests/Unit/CanonicalJsonTraitTest.php
@@ -25,6 +25,17 @@ class CanonicalJsonTraitTest extends TestCase
     }
 
     /**
+     * Indexed arrays with >= 10 items should not be changed.
+     */
+    public function testIndexedArraysAreNotChanged(): void
+    {
+        $indexed = array_fill(0, 20, 'Hello!');
+        $this->assertTrue(array_is_list($indexed));
+        $canonicalized = static::encodeJson($indexed);
+        $this->assertSame($indexed, static::decodeJson($canonicalized));
+    }
+
+    /**
      * @covers ::encodeJson
      */
     public function testSlashEscaping(): void

--- a/tests/Unit/CanonicalJsonTraitTest.php
+++ b/tests/Unit/CanonicalJsonTraitTest.php
@@ -29,10 +29,21 @@ class CanonicalJsonTraitTest extends TestCase
      */
     public function testIndexedArraysAreNotChanged(): void
     {
-        $indexed = array_fill(0, 20, 'Hello!');
-        $this->assertTrue(array_is_list($indexed));
-        $canonicalized = static::encodeJson($indexed);
-        $this->assertSame($indexed, static::decodeJson($canonicalized));
+        $original = [
+          'b' => array_fill(0, 20, 'Hello!'),
+          'a' => 'Canonically speaking, I go before b.',
+        ];
+        // The associative keys should be in their original, non-canonical
+        // order.
+        $this->assertSame(['b', 'a'], array_keys($original));
+        $this->assertTrue(array_is_list($original['b']));
+        $canonical = static::encodeJson($original);
+
+        $canonical = static::decodeJson($canonical);
+        // The associative keys should be in canonical order now, and the
+        // nested, indexed array should be unchanged.
+        $this->assertSame(['a', 'b'], array_keys($canonical));
+        $this->assertSame($original['b'], $canonical['b']);
     }
 
     /**


### PR DESCRIPTION
Fixes #340 properly. That PR's fatal flaw is that it only worked for the top level data structure, rather than recursively.