### PR TITLE
TargetsMetadata::toCanonicalJson() can try to access an undefined key

### DIFF
--- a/src/Metadata/TargetsMetadata.php
+++ b/src/Metadata/TargetsMetadata.php
@@ -82,7 +82,9 @@ class TargetsMetadata extends MetadataBase
 
         // Ensure that these will encode as objects even if they're empty.
         $normalized['targets'] = (object) $normalized['targets'];
-        $normalized['delegations']['keys'] = (object) $normalized['delegations']['keys'];
+        if (array_key_exists('delegations', $normalized)) {
+            $normalized['delegations']['keys'] = (object) $normalized['delegations']['keys'];
+        }
 
         return $normalized;
     }


### PR DESCRIPTION
If a TargetsMetadata object has no `delegations` key, `toCanonicalJson()` will still trigger an "Undefined key `delegations`" error from this bit:

```php
$normalized['delegations']['keys'] = (object) $normalized['delegations']['keys'];
```

We should ensure that $normalized has a `delegations` key before doing this.