### PR TITLE
Fix invalid canonical JSON of TargetsMetadata

### DIFF
--- a/src/Metadata/TargetsMetadata.php
+++ b/src/Metadata/TargetsMetadata.php
@@ -52,15 +52,17 @@ class TargetsMetadata extends MetadataBase
         foreach ($normalized['targets'] as $path => $target) {
             // Custom target info should always encode to an object, even if
             // it's empty.
-            if (array_key_exists('custom', $target)) {
-                $normalized['targets'][$path]['custom'] = (object) $target['custom'];
+            if (array_key_exists('custom', $target) && empty($target['custom'])) {
+                $normalized['targets'][$path]['custom'] = new \stdClass();
             }
         }
 
         // Ensure that these will encode as objects even if they're empty.
-        $normalized['targets'] = (object) $normalized['targets'];
-        if (array_key_exists('delegations', $normalized)) {
-            $normalized['delegations']['keys'] = (object) $normalized['delegations']['keys'];
+        if (empty($normalized['targets'])) {
+            $normalized['targets'] = new \stdClass();
+        }
+        if (array_key_exists('delegations', $normalized) && empty($normalized['delegations']['keys'])) {
+            $normalized['delegations']['keys'] = new \stdClass();
         }
 
         return $normalized;

--- a/tests/Metadata/TargetsMetadataTest.php
+++ b/tests/Metadata/TargetsMetadataTest.php
@@ -216,7 +216,6 @@ class TargetsMetadataTest extends MetadataBaseTest
     public function testKeysAreSorted(): void
     {
         $data = [
-            'signatures' => [],
             'signed' => [
                 '_type' => 'targets',
                 'version' => 1,
@@ -236,11 +235,13 @@ class TargetsMetadataTest extends MetadataBaseTest
                     ],
                 ],
             ],
+            'signatures' => [],
         ];
         $metadata = new TargetsMetadata($data, '');
 
         $decoded = static::decodeJson($metadata->toCanonicalJson());
         // The out-of-order keys should have been reordered.
+        $this->assertSame(['_type', 'delegations', 'targets', 'version'], array_keys($decoded));
         $this->assertSame(['baz', 'foo'], array_keys($decoded['targets']));
         $this->assertSame(['a', 'z'], array_keys($decoded['targets']['foo']['custom']));
         $this->assertSame(['a', 'z'], array_keys($decoded['delegations']['keys']));
@@ -249,7 +250,6 @@ class TargetsMetadataTest extends MetadataBaseTest
     public function testEmptyStructuresAreEncodedAsObjects(): void
     {
         $data = [
-            'signatures' => [],
             'signed' => [
                 '_type' => 'targets',
                 'version' => 1,
@@ -263,6 +263,7 @@ class TargetsMetadataTest extends MetadataBaseTest
                     'keys' => [],
                 ],
             ],
+            'signatures' => [],
         ];
         $metadata = new TargetsMetadata($data, '');
         $decoded = json_decode($metadata->toCanonicalJson());

--- a/tests/Metadata/TargetsMetadataTest.php
+++ b/tests/Metadata/TargetsMetadataTest.php
@@ -265,22 +265,13 @@ class TargetsMetadataTest extends MetadataBaseTest
             ],
         ];
         $metadata = new TargetsMetadata($data, '');
-
         $decoded = json_decode($metadata->toCanonicalJson());
         // Things that should be objects are still objects, despite being empty.
         $this->assertIsObject($decoded->targets->{'foo.txt'}->custom);
         $this->assertIsObject($decoded->delegations->keys);
 
-        $data = [
-            'signatures' => [],
-            'signed' => [
-                '_type' => 'targets',
-                'version' => 1,
-                'targets' => [],
-            ],
-        ];
+        $data['signed']['targets'] = [];
         $metadata = new TargetsMetadata($data, '');
-
         $decoded = json_decode($metadata->toCanonicalJson());
         // Things that should be objects are still objects, despite being empty.
         $this->assertIsObject($decoded->targets);


### PR DESCRIPTION
We ran into an issue where php-tuf was unable to verify a signature of a valid targets metadata file.

After some closer investigation we realized that this was caused by a mismatch between the canonical JSON that is generated by php-tuf and the canonical JSON that the CLI tool generated for the signature.

The root cause for is the fact that "toNormalizedArray" in TargetsMetadata converted multiple properties from an array to object. Because of that, "sortKey" in the CanonicalJsonTrait did not correctly recurse into the sublevels, leaving array keys in sublevels unsorted. That leads to an invalid canonical JSON.

In this PR we removed the toNormalizedArray method and instead decided to override the toCanonicalJSON method. That also is a better fit for this specific usecase, as the casting to object isn't meant to normalize the array itself but specifically modifiy the generated JSON output.