### PR TITLE
Make Repository::MAX_BYTES a public static int so it can be overridden

### DIFF
--- a/src/Client/Repository.php
+++ b/src/Client/Repository.php
@@ -20,7 +20,7 @@ class Repository
      *
      * @var int
      */
-    public const MAX_BYTES = 100000;
+    public static int $maxBytes = 100000;
 
     public function __construct(private SizeCheckingLoader $sizeCheckingLoader)
     {
@@ -39,7 +39,7 @@ class Repository
     public function getRoot(int $version): ?RootMetadata
     {
         try {
-            $data = $this->sizeCheckingLoader->load("$version.root.json", self::MAX_BYTES);
+            $data = $this->sizeCheckingLoader->load("$version.root.json", self::$maxBytes);
 
             return RootMetadata::createFromJson($data->getContents());
         } catch (RepoFileNotFound) {
@@ -58,7 +58,7 @@ class Repository
      */
     public function getTimestamp(): TimestampMetadata
     {
-        $data = $this->sizeCheckingLoader->load('timestamp.json', self::MAX_BYTES);
+        $data = $this->sizeCheckingLoader->load('timestamp.json', self::$maxBytes);
 
         return TimestampMetadata::createFromJson($data->getContents());
     }
@@ -71,7 +71,7 @@ class Repository
      *   snapshots are not used.
      * @param int|null $maxBytes
      *   The maximum number of bytes to download, or null to use
-     *   self::MAX_BYTES.
+     *   self::$maxBytes.
      *
      * @return \Tuf\Metadata\SnapshotMetadata
      *   The untrusted snapshot metadata.
@@ -81,7 +81,7 @@ class Repository
         $name = isset($version) ? "$version.snapshot" : 'snapshot';
         // If a maximum number of bytes was provided, we must download *exactly*
         // that number of bytes.
-        $data = $this->sizeCheckingLoader->load("$name.json", $maxBytes ?? self::MAX_BYTES, isset($maxBytes));
+        $data = $this->sizeCheckingLoader->load("$name.json", $maxBytes ?? self::$maxBytes, isset($maxBytes));
 
         return SnapshotMetadata::createFromJson($data->getContents());
     }
@@ -97,7 +97,7 @@ class Repository
      *   delegated role.
      * @param int|null $maxBytes
      *   The maximum number of bytes to download, or null to use
-     *   self::MAX_BYTES.
+     *   self::$maxBytes.
      *
      * @return \Tuf\Metadata\TargetsMetadata
      *   The untrusted targets metadata.
@@ -107,7 +107,7 @@ class Repository
         $name = isset($version) ? "$version.$role" : $role;
         // If a maximum number of bytes was provided, we must download *exactly*
         // that number of bytes.
-        $data = $this->sizeCheckingLoader->load("$name.json", $maxBytes ?? self::MAX_BYTES, isset($maxBytes));
+        $data = $this->sizeCheckingLoader->load("$name.json", $maxBytes ?? self::$maxBytes, isset($maxBytes));
 
         return TargetsMetadata::createFromJson($data->getContents(), $role);
     }

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -338,7 +338,7 @@ class Updater
             throw new NotFoundException($target, 'Target');
         }
 
-        $stream = $this->serverLoader->load($target, $targetsMetadata->getLength($target) ?? Repository::MAX_BYTES);
+        $stream = $this->serverLoader->load($target, $targetsMetadata->getLength($target) ?? Repository::$maxBytes);
         $this->verify($target, $stream);
         return $stream;
     }

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -1027,12 +1027,12 @@ abstract class UpdaterTest extends ClientTestBase
             'unknown snapshot length' => [
                 'TargetsLengthNoSnapshotLength',
                 'snapshot.json',
-                Repository::MAX_BYTES,
+                Repository::$maxBytes,
             ],
             'unknown targets length' => [
                 'Simple',
                 'targets.json',
-                Repository::MAX_BYTES,
+                Repository::$maxBytes,
             ],
             'known snapshot length' => [
                 'Simple',
@@ -1063,7 +1063,7 @@ abstract class UpdaterTest extends ClientTestBase
 
         // The length of the timestamp metadata is never known in advance, so it
         // is always downloaded with the maximum length.
-        $this->assertSame(Repository::MAX_BYTES, $this->serverFiles->maxBytes['timestamp.json'][0]);
+        $this->assertSame(Repository::$maxBytes, $this->serverFiles->maxBytes['timestamp.json'][0]);
         $this->assertSame($expectedLength, $this->serverFiles->maxBytes[$downloadedFileName][0]);
     }
 

--- a/tests/Unit/RepositoryTest.php
+++ b/tests/Unit/RepositoryTest.php
@@ -28,19 +28,19 @@ class RepositoryTest extends TestCase
         $repository = new Repository(new SizeCheckingLoader($loader));
 
         $this->assertInstanceOf(RootMetadata::class, $repository->getRoot(1));
-        $this->assertSame(Repository::MAX_BYTES, $loader->maxBytes['1.root.json'][0]);
+        $this->assertSame(Repository::$maxBytes, $loader->maxBytes['1.root.json'][0]);
 
         $this->assertNull($repository->getRoot(999));
-        $this->assertSame(Repository::MAX_BYTES, $loader->maxBytes['999.root.json'][0]);
+        $this->assertSame(Repository::$maxBytes, $loader->maxBytes['999.root.json'][0]);
 
         $this->assertInstanceOf(TimestampMetadata::class, $repository->getTimestamp());
-        $this->assertSame(Repository::MAX_BYTES, $loader->maxBytes['timestamp.json'][0]);
+        $this->assertSame(Repository::$maxBytes, $loader->maxBytes['timestamp.json'][0]);
 
         foreach ([1, null] as $version) {
             $fileName = isset($version) ? "$version.snapshot.json" : 'snapshot.json';
 
             $this->assertInstanceOf(SnapshotMetadata::class, $repository->getSnapshot($version));
-            $this->assertSame(Repository::MAX_BYTES, $loader->maxBytes[$fileName][0]);
+            $this->assertSame(Repository::$maxBytes, $loader->maxBytes[$fileName][0]);
 
             $metadataDir = $baseDir . '/server/metadata';
             $fileSize = filesize($metadataDir . '/' . $fileName);
@@ -51,7 +51,7 @@ class RepositoryTest extends TestCase
                 $fileName = isset($version) ? "$version.$role.json" : "$role.json";
 
                 $this->assertInstanceOf(TargetsMetadata::class, $repository->getTargets($version, $role));
-                $this->assertSame(Repository::MAX_BYTES, $loader->maxBytes[$fileName][0]);
+                $this->assertSame(Repository::$maxBytes, $loader->maxBytes[$fileName][0]);
 
                 $fileSize = filesize($metadataDir . '/' . $fileName);
                 $this->assertInstanceOf(TargetsMetadata::class, $repository->getTargets($version, $role, $fileSize));


### PR DESCRIPTION
Turns out that, for testing with Drupal's staging metadata, 100,000 bytes is not enough :( Ideally, the size of the metadata to download would be safely encoded by Rugged in `snapshot.json`, and there is an issue for that (https://gitlab.com/rugged/rugged/-/issues/126), but it's unclear when that will be fixed and released.

In the meantime, we should make it possible for Repository::MAX_BYTES to be changed, allowing us to work around this. So I propose we make it a `public static int` instead of a constant. That way, it will affect every instance of `Repository` the same way (thereby acting similarly to a constant), but mutable.