### PR TITLE
Adopt static caching

### DIFF
--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -348,20 +348,26 @@ class Updater
      *
      * @param string $target
      *   The path of the target file.
+     * @param bool $useCache
+     *   (optional) Whether to load the metadata from an internal static cache.
      *
      * @return \Tuf\Metadata\TargetsMetadata|null
      *   The targets metadata with information about the desired target, or null if no relevant metadata is found.
      */
-    protected function getMetadataForTarget(string $target): ?TargetsMetadata
+    protected function getMetadataForTarget(string $target, bool $useCache = true): ?TargetsMetadata
     {
+        static $cache = [];
+        if ($useCache && array_key_exists($target, $cache)) {
+            return $cache[$target];
+        }
         // Search the top level targets metadata.
         /** @var \Tuf\Metadata\TargetsMetadata $targetsMetadata */
         $targetsMetadata = $this->storage->getTargets();
         if ($targetsMetadata->hasTarget($target)) {
-            return $targetsMetadata;
+            return $cache[$target] = $targetsMetadata;
         }
         // Recursively search any delegated roles.
-        return $this->searchDelegatedRolesForTarget($targetsMetadata, $target, ['targets']);
+        return $cache[$target] = $this->searchDelegatedRolesForTarget($targetsMetadata, $target, ['targets']);
     }
 
     /**

--- a/src/Loader/StaticCacheLoader.php
+++ b/src/Loader/StaticCacheLoader.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tuf\Loader;
+
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * A data loader that maintains a static cache of already-loaded streams.
+ */
+class StaticCacheLoader implements LoaderInterface
+{
+    /**
+     * A static cache of already-loaded data streams, keyed by locator.
+     *
+     * @var \Psr\Http\Message\StreamInterface[]
+     */
+    private array $cache = [];
+
+    public function __construct(private LoaderInterface $decorated)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function load(string $locator, int $maxBytes): StreamInterface
+    {
+        if (array_key_exists($locator, $this->cache)) {
+            return $this->cache[$locator];
+        }
+        return $this->cache[$locator] = $this->decorated->load($locator, $maxBytes);
+    }
+
+    /**
+     * Resets the static cache.
+     */
+    public function reset(): void
+    {
+        $this->cache = [];
+    }
+}

--- a/tests/Unit/StaticCacheLoaderTest.php
+++ b/tests/Unit/StaticCacheLoaderTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tuf\Tests\Unit;
+
+use GuzzleHttp\Psr7\Utils;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Tuf\Loader\LoaderInterface;
+use Tuf\Loader\StaticCacheLoader;
+
+/**
+ * @covers \Tuf\Loader\StaticCacheLoader
+ */
+class StaticCacheLoaderTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testStaticCacheLoader(): void
+    {
+        $decorated = $this->prophesize(LoaderInterface::class);
+        $stream = Utils::streamFor('Row, row, row your boat...');
+
+        $locator = 'uno.txt';
+        $maxBytes = 59;
+        $decorated->load($locator, $maxBytes)
+            ->willReturn($stream)
+            ->shouldBeCalledTimes(2);
+
+        $loader = new StaticCacheLoader($decorated->reveal());
+        $this->assertSame($stream, $loader->load($locator, $maxBytes));
+        $this->assertSame($stream, $loader->load($locator, $maxBytes));
+        $loader->reset();
+        $this->assertSame($stream, $loader->load($locator, $maxBytes));
+    }
+}


### PR DESCRIPTION
Our Composer integration plugin currently has _terrible_ performance. All php-tuf/composer-integration#87 does is reduce our network traffic (which, to be clear, is a good thing). We're still talking to the server _a lot_, and therefore blocking asynchronous operations.

I think we should add static caching. Because here's the thing -- do we really expect data downloaded from the server to change _in the middle of a Composer operation_? And, if it does, isn't that bad? Wouldn't it lead to inconsistency and failed validation, if the TUF metadata we've loaded _into memory_ no longer matches what's coming from the server?

There are two places where I think static caching will give us a much-needed performance boost:

1. Loading data from the server. If we've already loaded something, then we should maintain it in memory, both for performance and consistency. If it needs to be refreshed from the server, well...that'll happen the next time the Composer plugin runs, since the static cache only lives in memory and has no persistence beyond the current PHP process. We can accomplish this by implementing a simple `LoaderInterface` decorator that implements a static cache, which the plugin should then take advantage of explicitly.
2. Figuring out which targets metadata contains the information about a particular target. If we have to search delegated roles, this can take an awful long time, and trigger another huge round of pinging the server. This should be an internal static cache of `getMetadataForTarget()` that maps a particular target name to an already-loaded metadata object.

Now, to be clear, both of these things could be done within the plugin itself. We don't _have_ to do this in PHP-TUF. But IMHO it's good practice and we should provide it.