### PR TITLE
Restore the use of promises

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "paragonie/sodium_compat": "^1.13",
         "symfony/validator": "^4.4 || ^5 || ^6",
         "guzzlehttp/psr7": "^2.4",
-        "symfony/polyfill-php81": "^1.27"
+        "symfony/polyfill-php81": "^1.27",
+        "guzzlehttp/promises": "^1.5"
     },
     "suggest": {
         "ext-sodium": "Provides faster verification of updates"

--- a/src/Client/Repository.php
+++ b/src/Client/Repository.php
@@ -39,7 +39,8 @@ class Repository
     public function getRoot(int $version): ?RootMetadata
     {
         try {
-            $data = $this->sizeCheckingLoader->load("$version.root.json", self::$maxBytes);
+            $data = $this->sizeCheckingLoader->load("$version.root.json", self::$maxBytes)
+              ->wait();
 
             return RootMetadata::createFromJson($data->getContents());
         } catch (RepoFileNotFound) {
@@ -58,7 +59,8 @@ class Repository
      */
     public function getTimestamp(): TimestampMetadata
     {
-        $data = $this->sizeCheckingLoader->load('timestamp.json', self::$maxBytes);
+        $data = $this->sizeCheckingLoader->load('timestamp.json', self::$maxBytes)
+          ->wait();
 
         return TimestampMetadata::createFromJson($data->getContents());
     }
@@ -81,7 +83,8 @@ class Repository
         $name = isset($version) ? "$version.snapshot" : 'snapshot';
         // If a maximum number of bytes was provided, we must download *exactly*
         // that number of bytes.
-        $data = $this->sizeCheckingLoader->load("$name.json", $maxBytes ?? self::$maxBytes, isset($maxBytes));
+        $data = $this->sizeCheckingLoader->load("$name.json", $maxBytes ?? self::$maxBytes, isset($maxBytes))
+          ->wait();
 
         return SnapshotMetadata::createFromJson($data->getContents());
     }
@@ -107,7 +110,8 @@ class Repository
         $name = isset($version) ? "$version.$role" : $role;
         // If a maximum number of bytes was provided, we must download *exactly*
         // that number of bytes.
-        $data = $this->sizeCheckingLoader->load("$name.json", $maxBytes ?? self::$maxBytes, isset($maxBytes));
+        $data = $this->sizeCheckingLoader->load("$name.json", $maxBytes ?? self::$maxBytes, isset($maxBytes))
+          ->wait();
 
         return TargetsMetadata::createFromJson($data->getContents(), $role);
     }

--- a/src/Loader/LoaderInterface.php
+++ b/src/Loader/LoaderInterface.php
@@ -2,7 +2,7 @@
 
 namespace Tuf\Loader;
 
-use Psr\Http\Message\StreamInterface;
+use GuzzleHttp\Promise\PromiseInterface;
 
 /**
  * Defines an interface to load data as a stream.
@@ -26,11 +26,11 @@ interface LoaderInterface
      * @param int $maxBytes
      *   The maximum number of bytes that should be read from the data source.
      *
-     * @return \Psr\Http\Message\StreamInterface
-     *   A data stream.
+     * @return \GuzzleHttp\Promise\PromiseInterface<\Psr\Http\Message\StreamInterface>
+     *   A promise wrapping a data stream.
      *
      * @throws \Tuf\Exception\RepoFileNotFound
      *   If the data cannot be found.
      */
-    public function load(string $locator, int $maxBytes): StreamInterface;
+    public function load(string $locator, int $maxBytes): PromiseInterface;
 }

--- a/src/Loader/SizeCheckingLoader.php
+++ b/src/Loader/SizeCheckingLoader.php
@@ -2,6 +2,7 @@
 
 namespace Tuf\Loader;
 
+use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\StreamInterface;
 use Tuf\Exception\DownloadSizeException;
@@ -18,21 +19,22 @@ class SizeCheckingLoader implements LoaderInterface
     /**
      * {@inheritDoc}
      */
-    public function load(string $locator, int $maxBytes, bool $exact = false): StreamInterface
+    public function load(string $locator, int $maxBytes, bool $exact = false): PromiseInterface
     {
-        $data = $this->decorated->load($locator, $maxBytes);
-
-        $size = $this->getSize($data, $maxBytes);
-        // If we're doing an exact size check, the stream MUST be exactly
-        // $maxBytes in size.
-        if ($exact) {
-            if ($size !== $maxBytes) {
-                throw new DownloadSizeException("Expected $locator to be $maxBytes bytes.");
-            }
-        } elseif ($size > $maxBytes) {
-            throw new DownloadSizeException("$locator exceeded $maxBytes bytes");
-        }
-        return $data;
+        return $this->decorated->load($locator, $maxBytes)
+          ->then(function (StreamInterface $data) use ($locator, $maxBytes, $exact) {
+              $size = $this->getSize($data, $maxBytes);
+              // If we're doing an exact size check, the stream MUST be exactly
+              // $maxBytes in size.
+              if ($exact) {
+                  if ($size !== $maxBytes) {
+                      throw new DownloadSizeException("Expected $locator to be $maxBytes bytes.");
+                  }
+              } elseif ($size > $maxBytes) {
+                  throw new DownloadSizeException("$locator exceeded $maxBytes bytes");
+              }
+              return $data;
+          });
     }
 
     /**

--- a/tests/Client/HashedBinsTest.php
+++ b/tests/Client/HashedBinsTest.php
@@ -19,7 +19,7 @@ class HashedBinsTest extends ClientTestBase
         foreach ($targets as $name) {
             // By default, the fixture builder puts "Contents: FILENAME" into
             // the target files it creates.
-            $this->assertSame("Contents: $name", $updater->download($name)->getContents());
+            $this->assertSame("Contents: $name", $updater->download($name)->wait()->getContents());
         }
     }
 }

--- a/tests/Client/RoleDownloadLimitTest.php
+++ b/tests/Client/RoleDownloadLimitTest.php
@@ -28,7 +28,7 @@ class RoleDownloadLimitTest extends ClientTestBase
         // Ensure the file can found if the maximum role limit is 100.
         $testFileContents = $this->serverFiles[$fileName];
         self::assertNotEmpty($testFileContents);
-        self::assertSame($testFileContents, $this->getUpdater()->download($fileName)->getContents());
+        self::assertSame($testFileContents, $this->getUpdater()->download($fileName)->wait()->getContents());
 
         // Ensure the file can not found if the maximum role limit is 3.
         self::expectException(NotFoundException::class);

--- a/tests/Client/TestLoader.php
+++ b/tests/Client/TestLoader.php
@@ -2,8 +2,9 @@
 
 namespace Tuf\Tests\Client;
 
+use GuzzleHttp\Promise\Create;
+use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Utils;
-use Psr\Http\Message\StreamInterface;
 use Tuf\Exception\RepoFileNotFound;
 use Tuf\Loader\LoaderInterface;
 
@@ -51,14 +52,15 @@ class TestLoader extends \ArrayObject implements LoaderInterface
     /**
      * {@inheritDoc}
      */
-    public function load(string $locator, int $maxBytes): StreamInterface
+    public function load(string $locator, int $maxBytes): PromiseInterface
     {
         $this->maxBytes[$locator][] = $maxBytes;
 
         if ($this->offsetExists($locator)) {
-            return Utils::streamFor($this[$locator]);
+            $stream = Utils::streamFor($this[$locator]);
+            return Create::promiseFor($stream);
         } else {
-            throw new RepoFileNotFound("File $locator not found.");
+            return Create::rejectionFor(new RepoFileNotFound("File $locator not found."));
         }
     }
 }

--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -49,7 +49,7 @@ abstract class UpdaterTest extends ClientTestBase
         $testFilePath = static::getFixturePath($fixtureName, "server/targets/$target", false);
         $testFileContents = file_get_contents($testFilePath);
         self::assertNotEmpty($testFileContents);
-        $this->assertSame($testFileContents, $this->getUpdater()->download($target)->getContents());
+        $this->assertSame($testFileContents, $this->getUpdater()->download($target)->wait()->getContents());
         // Ensure that client downloads only the delegated role JSON files that
         // are needed to find the metadata for the target.
         $this->assertMetadataVersions($expectedFileVersions, $this->clientStorage);

--- a/tests/Client/VerifiedDownloadTest.php
+++ b/tests/Client/VerifiedDownloadTest.php
@@ -29,7 +29,7 @@ class VerifiedDownloadTest extends ClientTestBase
 
         $testFilePath = static::getFixturePath($fixture, 'server/targets/testtarget.txt', false);
         $testFileContents = file_get_contents($testFilePath);
-        $this->assertSame($testFileContents, $updater->download('testtarget.txt')->getContents());
+        $this->assertSame($testFileContents, $updater->download('testtarget.txt')->wait()->getContents());
 
         // If the file fetcher returns a file stream, the updater should NOT try
         // to read the contents of the stream into memory.
@@ -51,7 +51,7 @@ class VerifiedDownloadTest extends ClientTestBase
         $stream = Utils::streamFor('invalid data');
         $this->serverFiles['testtarget.txt'] = $stream;
         try {
-            $updater->download('testtarget.txt');
+            $updater->download('testtarget.txt')->wait();
             $this->fail('Expected InvalidHashException to be thrown, but it was not.');
         } catch (InvalidHashException $e) {
             $this->assertSame("Invalid sha256 hash for testtarget.txt", $e->getMessage());


### PR DESCRIPTION
In order to support asynchronously fetching information about delegated targets, we need to start using promises again.

(I'll fill more of this in later.)