### PR TITLE
Always fetch targets metadata asynchronously

### DIFF
--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -382,7 +382,7 @@ class Updater
         $targetsVersion = $this->storage->getRoot()->supportsConsistentSnapshots()
             ? $fileInfo['version']
             : null;
-        $newTargetsData = $this->server->getTargets($targetsVersion, $role, $fileInfo['length'] ?? null);
+        $newTargetsData = $this->server->getTargets($targetsVersion, $role, $fileInfo['length'] ?? null)->wait();
         $this->universalVerifier->verify(TargetsMetadata::TYPE, $newTargetsData);
         // § 5.5.6
         $this->storage->save($newTargetsData);

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -382,10 +382,13 @@ class Updater
         $targetsVersion = $this->storage->getRoot()->supportsConsistentSnapshots()
             ? $fileInfo['version']
             : null;
-        $newTargetsData = $this->server->getTargets($targetsVersion, $role, $fileInfo['length'] ?? null)->wait();
-        $this->universalVerifier->verify(TargetsMetadata::TYPE, $newTargetsData);
-        // § 5.5.6
-        $this->storage->save($newTargetsData);
+        $this->server->getTargets($targetsVersion, $role, $fileInfo['length'] ?? null)
+          ->then(function (TargetsMetadata $newTargetsData) {
+              $this->universalVerifier->verify(TargetsMetadata::TYPE, $newTargetsData);
+              // § 5.5.6
+              $this->storage->save($newTargetsData);
+          })
+          ->wait();
     }
 
     /**

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -391,6 +391,7 @@ class Updater
               $this->universalVerifier->verify(TargetsMetadata::TYPE, $newTargetsData);
               // § 5.5.6
               $this->storage->save($newTargetsData);
+              return $newTargetsData;
           });
     }
 
@@ -443,9 +444,9 @@ class Updater
             // Targets must match the paths of all roles in the delegation chain, so if the path does not match,
             // do not evaluate this role or any roles it delegates to.
             if ($delegatedRole->matchesPath($target)) {
-                $this->fetchAndVerifyTargetsMetadata($delegatedRoleName)->wait();
                 /** @var \Tuf\Metadata\TargetsMetadata $delegatedTargetsMetadata */
-                $delegatedTargetsMetadata = $this->storage->getTargets($delegatedRoleName);
+                $delegatedTargetsMetadata = $this->fetchAndVerifyTargetsMetadata($delegatedRoleName)
+                  ->wait();
                 if ($delegatedTargetsMetadata->hasTarget($target)) {
                     return $delegatedTargetsMetadata;
                 }

--- a/tests/TestHelpers/TestRepository.php
+++ b/tests/TestHelpers/TestRepository.php
@@ -2,8 +2,9 @@
 
 namespace Tuf\Tests\TestHelpers;
 
+use GuzzleHttp\Promise\Create;
+use GuzzleHttp\Promise\PromiseInterface;
 use Tuf\Client\Repository;
-use Tuf\Metadata\TargetsMetadata;
 
 /**
  * Allows mocked metadata objects to be returned from the server in tests.
@@ -22,11 +23,11 @@ class TestRepository extends Repository
     /**
      * {@inheritDoc}
      */
-    public function getTargets(?int $version, string $role = 'targets', int $maxBytes = null): TargetsMetadata
+    public function getTargets(?int $version, string $role = 'targets', int $maxBytes = null): PromiseInterface
     {
         if (!empty($this->targets[$role])) {
             $version ??= array_key_last($this->targets[$role]);
-            return $this->targets[$role][$version];
+            return Create::promiseFor($this->targets[$role][$version]);
         }
         return parent::getTargets($version, $role, $maxBytes);
     }

--- a/tests/Unit/RepositoryTest.php
+++ b/tests/Unit/RepositoryTest.php
@@ -50,11 +50,11 @@ class RepositoryTest extends TestCase
             foreach (['targets', 'unclaimed'] as $role) {
                 $fileName = isset($version) ? "$version.$role.json" : "$role.json";
 
-                $this->assertInstanceOf(TargetsMetadata::class, $repository->getTargets($version, $role));
+                $this->assertInstanceOf(TargetsMetadata::class, $repository->getTargets($version, $role)->wait());
                 $this->assertSame(Repository::$maxBytes, $loader->maxBytes[$fileName][0]);
 
                 $fileSize = filesize($metadataDir . '/' . $fileName);
-                $this->assertInstanceOf(TargetsMetadata::class, $repository->getTargets($version, $role, $fileSize));
+                $this->assertInstanceOf(TargetsMetadata::class, $repository->getTargets($version, $role, $fileSize)->wait());
                 $this->assertSame($fileSize, $loader->maxBytes[$fileName][1]);
             }
         }


### PR DESCRIPTION
This is the follow-up of #356.

As part of searching for delegated targets in parallel, we need to be able to fetch targets metadata asynchronously, using promises. We do NOT need to make root, timestamp, or snapshot metadata asynchronous -- they are always loaded and verified in a synchronous manner according to TUF's design. But targets metadata does need to be asynchronous in nature, since that's what we download as we search the delegation tree.

Once this is done, there will be at least one other follow-up to make the logic of `searchDelegatedRolesForTarget()` asynchronous too.