### PR TITLE
Prevent path traversal by URL-encoding the names of all saved metadata

### DIFF
--- a/src/Client/DurableStorage/FileStorage.php
+++ b/src/Client/DurableStorage/FileStorage.php
@@ -39,7 +39,7 @@ class FileStorage extends StorageBase
      */
     protected function toPath(string $name): string
     {
-        return $this->basePath . DIRECTORY_SEPARATOR . $name . '.json';
+        return $this->basePath . DIRECTORY_SEPARATOR . urlencode($name) . '.json';
     }
 
     protected function read(string $name): ?string

--- a/tests/Unit/FileStorageTest.php
+++ b/tests/Unit/FileStorageTest.php
@@ -147,7 +147,7 @@ class FileStorageTest extends TestCase
         $metadata->ensureIsTrusted()->shouldBeCalled();
         $storage->save($metadata->reveal());
 
-        $expectedFileName = urlencode($roleName) . '.json';
+        $expectedFileName = 'hello%2F..%2Fthere%21.json';
         $this->assertFileExists($dir . '/' . $expectedFileName);
 
         $method = new \ReflectionMethod($storage, 'read');

--- a/tests/Unit/FileStorageTest.php
+++ b/tests/Unit/FileStorageTest.php
@@ -5,6 +5,7 @@ namespace Tuf\Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Tuf\Client\DurableStorage\FileStorage;
+use Tuf\Metadata\MetadataBase;
 use Tuf\Metadata\RootMetadata;
 use Tuf\Metadata\SnapshotMetadata;
 use Tuf\Metadata\TargetsMetadata;
@@ -130,5 +131,26 @@ class FileStorageTest extends TestCase
         $this->expectException('LogicException');
         $this->expectExceptionMessage('Could not load root metadata.');
         $storage->getRoot();
+    }
+
+    public function testFileNamesAreUrlEncoded(): void
+    {
+        $roleName = 'hello/../there!';
+        $fileContents = '{["A test of your mettle"]}';
+
+        $dir = sys_get_temp_dir();
+        $storage = new FileStorage($dir);
+
+        $metadata = $this->prophesize(MetadataBase::class);
+        $metadata->getRole()->willReturn($roleName);
+        $metadata->getSource()->willReturn($fileContents);
+        $metadata->ensureIsTrusted()->shouldBeCalled();
+        $storage->save($metadata->reveal());
+
+        $expectedFileName = urlencode($roleName) . '.json';
+        $this->assertFileExists($dir . '/' . $expectedFileName);
+
+        $method = new \ReflectionMethod($storage, 'read');
+        $this->assertSame($fileContents, $method->invoke($storage, $roleName));
     }
 }

--- a/tests/Unit/FileStorageTest.php
+++ b/tests/Unit/FileStorageTest.php
@@ -151,6 +151,7 @@ class FileStorageTest extends TestCase
         $this->assertFileExists($dir . '/' . $expectedFileName);
 
         $method = new \ReflectionMethod($storage, 'read');
+        $method->setAccessible(true);
         $this->assertSame($fileContents, $method->invoke($storage, $roleName));
     }
 }


### PR DESCRIPTION
Right now, we save trusted metadata using whatever role name it has. If the role name has path traversal components (for example, `parent_role/../grandparent_role`), the file would be saved as `path/to/metadata/parent_role/../grandparent_role.json`. That's unauthorized filesystem access.

To fix this, the role name should be URL-encoded. To continue the previous example, it should be saved as `path/to/metadata/parent_role%2F..%2Fgrandparent_role.json` to prevent path traversal.