### PR TITLE
Drop compatibility with Guzzle 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "squizlabs/php_codesniffer": "^3.7",
         "slevomat/coding-standard": "^8.2",
         "phpspec/prophecy-phpunit": "^2",
-        "guzzlehttp/guzzle": "^6.5 || ^7.2",
+        "guzzlehttp/guzzle": "^7.2",
         "phpspec/prophecy": "^1.16"
     },
     "license": "MIT",
@@ -21,7 +21,7 @@
         "symfony/validator": "^4.4 || ^5 || ^6",
         "guzzlehttp/psr7": "^2.4",
         "symfony/polyfill-php81": "^1.27",
-        "guzzlehttp/promises": "^1.5 || ^2.0"
+        "guzzlehttp/promises": "^2"
     },
     "suggest": {
         "ext-sodium": "Provides faster verification of updates"

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
         "squizlabs/php_codesniffer": "^3.7",
         "slevomat/coding-standard": "^8.2",
         "phpspec/prophecy-phpunit": "^2",
-        "guzzlehttp/guzzle": "^7.2",
         "phpspec/prophecy": "^1.16"
     },
     "license": "MIT",


### PR DESCRIPTION
We're not getting anything out of Guzzle 6 except for extra complexity, as well as having to walk carefully around the minefield of compatibility between two different _major_ versions of `guzzlehttp/promises`, which is a library we actually _do_ depend on. Let's drop compatibility with Guzzle 6.

For Drupal's part, it hasn't been compatible with Guzzle 6 since Drupal 9, which is now EOL.