### PR TITLE
Use Symfony's Unique constraint where appropriate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^8.1",
         "ext-json": "*",
         "paragonie/sodium_compat": "^1.13",
-        "symfony/validator": "^6",
+        "symfony/validator": "^6.1",
         "guzzlehttp/psr7": "^2.4",
         "symfony/polyfill-php81": "^1.27",
         "guzzlehttp/promises": "^2"

--- a/src/Metadata/ConstraintsTrait.php
+++ b/src/Metadata/ConstraintsTrait.php
@@ -58,7 +58,6 @@ trait ConstraintsTrait
         return [
             'hashes' => [
                 new Count(['min' => 1]),
-                new Type('array'),
               // The keys for 'hashes is not know but they all must be strings.
                 new All([
                     new Type('string'),
@@ -110,7 +109,6 @@ trait ConstraintsTrait
         return [
             'keyids' => [
                 new Count(['min' => 1]),
-                new Type('array'),
                 // The keys for 'hashes is not know but they all must be strings.
                 new All([
                     new Type('string'),

--- a/src/Metadata/RootMetadata.php
+++ b/src/Metadata/RootMetadata.php
@@ -26,7 +26,6 @@ class RootMetadata extends MetadataBase
     {
         $options = parent::getSignedCollectionOptions();
         $options['fields']['keys'] = new Required([
-            new Type('array'),
             new Count(['min' => 1]),
             new All([
                 static::getKeyConstraints(),

--- a/src/Metadata/SnapshotMetadata.php
+++ b/src/Metadata/SnapshotMetadata.php
@@ -24,7 +24,6 @@ class SnapshotMetadata extends FileInfoMetadataBase
     {
         $options = parent::getSignedCollectionOptions();
         $options['fields']['meta'] = new Required([
-            new Type('array'),
             new Count(['min' => 1]),
             new All([
                 new Collection(

--- a/src/Metadata/TargetsMetadata.php
+++ b/src/Metadata/TargetsMetadata.php
@@ -83,26 +83,26 @@ class TargetsMetadata extends MetadataBase
                     new All([
                         new Collection([
                             'fields' => [
-                                    'name' => [
-                                        new NotBlank(),
+                                'name' => [
+                                    new NotBlank(),
+                                    new Type('string'),
+                                ],
+                                'paths' => new Optional([
+                                    new All([
                                         new Type('string'),
-                                    ],
-                                    'paths' => new Optional([
-                                        new All([
-                                            new Type('string'),
-                                            new NotBlank(),
-                                        ]),
+                                        new NotBlank(),
                                     ]),
-                                    'path_hash_prefixes' => new Optional([
-                                        new All([
-                                            new Type('string'),
-                                            new NotBlank(),
-                                        ]),
+                                ]),
+                                'path_hash_prefixes' => new Optional([
+                                    new All([
+                                        new Type('string'),
+                                        new NotBlank(),
                                     ]),
-                                    'terminating' => [
-                                        new Type('boolean'),
-                                    ],
-                                ] + static::getKeyidsConstraints() + static::getThresholdConstraints(),
+                                ]),
+                                'terminating' => [
+                                    new Type('boolean'),
+                                ],
+                            ] + static::getKeyidsConstraints() + static::getThresholdConstraints(),
                         ]),
                     ]),
                     new Unique([

--- a/src/Metadata/TimestampMetadata.php
+++ b/src/Metadata/TimestampMetadata.php
@@ -24,7 +24,6 @@ class TimestampMetadata extends FileInfoMetadataBase
     {
         $options = parent::getSignedCollectionOptions();
         $options['fields']['meta'] = new Required([
-            new Type('array'),
             new Count(['min' => 1]),
             new All([
                 new Collection([

--- a/tests/Metadata/MetaDataBaseTest.php
+++ b/tests/Metadata/MetaDataBaseTest.php
@@ -312,6 +312,7 @@ abstract class MetadataBaseTest extends TestCase
                 $newValue = 'Abb';
                 break;
             case 'array':
+            case 'iterable':
                 $newValue = 3060;
                 break;
             case 'boolean':

--- a/tests/Metadata/TargetsMetadataTest.php
+++ b/tests/Metadata/TargetsMetadataTest.php
@@ -115,8 +115,8 @@ class TargetsMetadataTest extends MetadataBaseTest
         $data[] = ["signed:targets:$target:custom", 'array'];
 
         $role = $this->getFixtureNestedArrayFirstKey($this->validJson, ['signed', 'delegations', 'roles']);
-        $data[] = ["signed:delegations:roles:$role:paths", 'array'];
-        $data[] = ["signed:delegations:roles:$role:path_hash_prefixes", 'array'];
+        $data[] = ["signed:delegations:roles:$role:paths", 'iterable'];
+        $data[] = ["signed:delegations:roles:$role:path_hash_prefixes", 'iterable'];
         return $data;
     }
 


### PR DESCRIPTION
This fixes #317.

It also removes the redundant use of `new Type('array')` in places where we're also using `new All([...])`. [The `All` validator ensures that it's given an array or a `Traversable`](https://github.com/symfony/validator/blob/6.1/Constraints/AllValidator.php#L37), which means we don't also need to specify `new Type('array')`. (Maybe we did in earlier versions of Symfony Validator, but it's not necessary in 6.1.)