### PR TITLE
Completely remove support for keyid_hash_algorithms

### DIFF
--- a/src/Key.php
+++ b/src/Key.php
@@ -88,17 +88,9 @@ final class Key
     public function getComputedKeyId(): string
     {
         // @see https://github.com/secure-systems-lab/securesystemslib/blob/master/securesystemslib/keys.py
-        // The keyid_hash_algorithms array value is based on the TUF settings,
-        // it's not expected to be part of the key metadata. The fact that it is
-        // currently included is a quirk of the TUF python code that may be
-        // fixed in future versions. Calculate using the normal TUF settings
-        // since this is how it's calculated in the securesystemslib code and
-        // any value for keyid_hash_algorithms in the key data in root.json is
-        // ignored.
         $canonical = self::encodeJson([
             'keytype' => $this->getType(),
             'scheme' => $this->scheme,
-            'keyid_hash_algorithms' => ['sha256', 'sha512'],
             'keyval' => [
                 'public' => $this->getPublic(),
             ],

--- a/src/Metadata/ConstraintsTrait.php
+++ b/src/Metadata/ConstraintsTrait.php
@@ -6,11 +6,9 @@ namespace Tuf\Metadata;
 use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\Count;
-use Symfony\Component\Validator\Constraints\EqualTo;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Constraints\IdenticalTo;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Constraints\Optional;
 use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Component\Validator\Validation;
 use Tuf\Exception\MetadataException;
@@ -129,15 +127,6 @@ trait ConstraintsTrait
     protected static function getKeyConstraints(): Collection
     {
         return new Collection([
-            // This field is not part of the TUF specification and is being
-            // removed from the Python TUF reference implementation in
-            // https://github.com/theupdateframework/tuf/issues/848.
-            // If it is provided though we only support the default value which
-            // is passed on from a setting in the Python `securesystemslib`
-            // library.
-            'keyid_hash_algorithms' => new Optional([
-                new EqualTo(['value' => ["sha256", "sha512"]]),
-            ]),
             'keytype' => [
                 new Type('string'),
                 new IdenticalTo('ed25519'),

--- a/tests/FixtureBuilder/Key.php
+++ b/tests/FixtureBuilder/Key.php
@@ -56,7 +56,6 @@ final class Key
             'keyval' => [
                 'public' => sodium_bin2hex($this->publicKey),
             ],
-            'keyid_hash_algorithms' => ['sha256', 'sha512'],
         ];
     }
 

--- a/tests/Metadata/RootMetadataTest.php
+++ b/tests/Metadata/RootMetadataTest.php
@@ -192,24 +192,6 @@ class RootMetadataTest extends MetadataBaseTest
         }
     }
 
-    /**
-     * Test that keyid_hash_algorithms must equal the exact value.
-     *
-     * @see \Tuf\Metadata\ConstraintsTrait::getKeyConstraints()
-     */
-    public function testKeyidHashAlgorithms()
-    {
-        $json = $this->clientStorage->read($this->validJson);
-        $data = json_decode($json, true);
-        $keyId = key($data['signed']['keys']);
-        $data['signed']['keys'][$keyId]['keyid_hash_algorithms'][1] = 'sha513';
-        self::expectException(MetadataException::class);
-        $expectedMessage = preg_quote("Array[signed][keys][$keyId][keyid_hash_algorithms]:", '/');
-        $expectedMessage .= '.* This value should be equal to array';
-        self::expectExceptionMessageMatches("/$expectedMessage/s");
-        static::callCreateFromJson(json_encode($data));
-    }
-
     public function testInvalidKeyType(): void
     {
         $metadata = json_decode($this->clientStorage->read($this->validJson), true);

--- a/tests/Metadata/TargetsMetadataTest.php
+++ b/tests/Metadata/TargetsMetadataTest.php
@@ -201,24 +201,6 @@ class TargetsMetadataTest extends MetadataBaseTest
         $this->assertSame('other_role', $metadata->getRole());
     }
 
-    /**
-     * Test that keyid_hash_algorithms must equal the exact value.
-     *
-     * @see \Tuf\Metadata\ConstraintsTrait::getKeyConstraints()
-     */
-    public function testKeyidHashAlgorithms()
-    {
-        $json = $this->clientStorage->read($this->validJson);
-        $data = json_decode($json, true);
-        $keyId = key($data['signed']['delegations']['keys']);
-        $data['signed']['delegations']['keys'][$keyId]['keyid_hash_algorithms'][1] = 'sha513';
-        self::expectException(MetadataException::class);
-        $expectedMessage = preg_quote("Array[signed][delegations][keys][$keyId][keyid_hash_algorithms]:", '/');
-        $expectedMessage .= '.* This value should be equal to array';
-        self::expectExceptionMessageMatches("/$expectedMessage/s");
-        static::callCreateFromJson(json_encode($data));
-    }
-
     public function testDuplicateDelegatedRoleNames(): void
     {
         $json = $this->clientStorage->read($this->validJson);

--- a/tests/Unit/KeyTest.php
+++ b/tests/Unit/KeyTest.php
@@ -15,12 +15,10 @@ class KeyTest extends TestCase
      * @covers ::getComputedKeyId
      * @covers ::getPublic
      * @covers ::getType
-     *
-     * @dataProvider providerCreateFromMetadata
      */
-    public function testCreateFromMetadata(array $data): void
+    public function testCreateFromMetadata(): void
     {
-        $data += [
+        $data = [
             'keytype' => 'ed25519',
             'scheme' => 'scheme-ed11111',
             'keyval' => ['public' => '12345'],
@@ -30,7 +28,6 @@ class KeyTest extends TestCase
         self::assertSame('ed25519', $key->getType());
         self::assertSame('12345', $key->getPublic());
         $keySortedCanonicalStruct = [
-            'keyid_hash_algorithms' => ['sha256', 'sha512'],
             'keytype' => 'ed25519',
             'keyval' => ['public' => '12345'],
             'scheme' => 'scheme-ed11111',
@@ -38,23 +35,5 @@ class KeyTest extends TestCase
         $keyCanonicalForm = json_encode($keySortedCanonicalStruct, JSON_UNESCAPED_SLASHES);
 
         self::assertSame(hash('sha256', $keyCanonicalForm), $key->getComputedKeyId());
-    }
-
-    /**
-     * Dataprovider for testCreateFromMetadata
-     * @return mixed[]
-     */
-    public function providerCreateFromMetadata(): array
-    {
-        return [
-            'without keyid_hash_algorithms' => [
-                [],
-            ],
-            'with keyid_hash_algorithms' => [
-                [
-                    'keyid_hash_algorithms' => ["sha256", "sha512"],
-                ],
-            ]
-        ];
     }
 }


### PR DESCRIPTION
The `keyid_hash_algorithms` field is no longer part of the TUF specification: https://theupdateframework.github.io/specification/latest/#file-formats-keys

We should remove support for it and the related test coverage.