### PR TITLE
Remove additional redundant uses of Symfony's Type constraint

### DIFF
--- a/src/DelegatedRole.php
+++ b/src/DelegatedRole.php
@@ -53,14 +53,12 @@ class DelegatedRole extends Role
             // `paths` is mutually exclusive with `path_hash_prefixes`.
             // @see ::validate()
             'paths' => new Optional([
-                new Type('array'),
                 new All([
                     new Type('string'),
                     new NotBlank(),
                 ]),
             ]),
             'path_hash_prefixes' => new Optional([
-                new Type('array'),
                 new All([
                     new Type('string'),
                     new NotBlank(),

--- a/src/Metadata/ConstraintsTrait.php
+++ b/src/Metadata/ConstraintsTrait.php
@@ -130,7 +130,6 @@ trait ConstraintsTrait
                 new IdenticalTo('ed25519'),
             ],
             'keyval' => [
-                new Type('array'),
                 new Collection([
                     'public' => [
                         new Type('string'),

--- a/tests/Unit/DelegatedRoleTest.php
+++ b/tests/Unit/DelegatedRoleTest.php
@@ -158,10 +158,10 @@ class DelegatedRoleTest extends RoleTest
     }
 
     /**
-     * @testWith ["paths", "Not an array!", ["paths"], "This value should be of type array."]
+     * @testWith ["paths", "Not an array!", ["paths"], "This value should be of type iterable."]
      *   ["paths", [""], ["paths", 0], "This value should not be blank."]
      *   ["paths", [38], ["paths", 0], "This value should be of type string."]
-     *   ["path_hash_prefixes", "Not an array!", ["path_hash_prefixes"], "This value should be of type array."]
+     *   ["path_hash_prefixes", "Not an array!", ["path_hash_prefixes"], "This value should be of type iterable."]
      *   ["path_hash_prefixes", [""], ["path_hash_prefixes", 0], "This value should not be blank."]
      *   ["path_hash_prefixes", [38], ["path_hash_prefixes", 0], "This value should be of type string."]
      */


### PR DESCRIPTION
In #368, we removed redundant uses of the `Type` constraint. I missed a few spots, though.