### PR TITLE
Remove Symfony's PHP 8.1 polyfill from dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "paragonie/sodium_compat": "^1.13",
         "symfony/validator": "^6.1",
         "guzzlehttp/psr7": "^2.4",
-        "symfony/polyfill-php81": "^1.27",
         "guzzlehttp/promises": "^2"
     },
     "suggest": {


### PR DESCRIPTION
We depend directly on PHP 8.1 or later, so we don't need this polyfill.