### PR TITLE
Completely remove Prophecy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,6 @@
         "symfony/phpunit-bridge": "^5",
         "squizlabs/php_codesniffer": "^3.7",
         "slevomat/coding-standard": "^8.2",
-        "phpspec/prophecy-phpunit": "^2",
-        "phpspec/prophecy": "^1.16",
         "symfony/filesystem": "^6.4"
     },
     "license": "MIT",

--- a/tests/Client/SnapshotHashesTest.php
+++ b/tests/Client/SnapshotHashesTest.php
@@ -2,7 +2,6 @@
 
 namespace Tuf\Tests\Client;
 
-use Prophecy\PhpUnit\ProphecyTrait;
 use Tuf\Exception\MetadataException;
 use Tuf\Metadata\TargetsMetadata;
 use Tuf\Tests\ClientTestBase;
@@ -12,8 +11,6 @@ use Tuf\Tests\ClientTestBase;
  */
 class SnapshotHashesTest extends ClientTestBase
 {
-    use ProphecyTrait;
-
     /**
      * @testWith ["consistent"]
      *   ["inconsistent"]

--- a/tests/Client/VerifiedDownloadTest.php
+++ b/tests/Client/VerifiedDownloadTest.php
@@ -3,7 +3,6 @@
 namespace Tuf\Tests\Client;
 
 use GuzzleHttp\Psr7\Utils;
-use Prophecy\PhpUnit\ProphecyTrait;
 use Tuf\Exception\Attack\InvalidHashException;
 use Tuf\Exception\NotFoundException;
 use Tuf\Tests\ClientTestBase;
@@ -13,8 +12,6 @@ use Tuf\Tests\ClientTestBase;
  */
 class VerifiedDownloadTest extends ClientTestBase
 {
-    use ProphecyTrait;
-
     /**
      * @testWith ["consistent"]
      *   ["inconsistent"]
@@ -33,11 +30,16 @@ class VerifiedDownloadTest extends ClientTestBase
 
         // If the file fetcher returns a file stream, the updater should NOT try
         // to read the contents of the stream into memory.
-        $stream = $this->prophesize('\Psr\Http\Message\StreamInterface');
-        $stream->getMetadata('uri')->willReturn($testFilePath);
-        $stream->getContents()->shouldNotBeCalled();
-        $stream->rewind()->shouldNotBeCalled();
-        $stream->getSize()->willReturn(strlen($testFileContents));
+        $stream = $this->createMock('\Psr\Http\Message\StreamInterface');
+        $stream->expects($this->any())
+            ->method('getMetadata')
+            ->with('uri')
+            ->willReturn($testFilePath);
+        $stream->expects($this->never())->method('getContents');
+        $stream->expects($this->never())->method('rewind');
+        $stream->expects($this->any())
+            ->method('getSize')
+            ->willReturn(strlen($testFileContents));
         $updater->download('testtarget.txt');
 
         // If the target isn't known, we should get an exception.

--- a/tests/SignatureVerifierTest.php
+++ b/tests/SignatureVerifierTest.php
@@ -3,7 +3,6 @@
 namespace Tuf\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
 use Tuf\Client\SignatureVerifier;
 use Tuf\Exception\NotFoundException;
 use Tuf\Metadata\RootMetadata;
@@ -16,7 +15,6 @@ use Tuf\Tests\TestHelpers\FixturesTrait;
 class SignatureVerifierTest extends TestCase
 {
     use FixturesTrait;
-    use ProphecyTrait;
 
     /**
      * @covers ::createFromRootMetadata
@@ -56,12 +54,14 @@ class SignatureVerifierTest extends TestCase
         $rootMetadata = file_get_contents($fixturePath . '/1.root.json');
         $rootMetadata = RootMetadata::createFromJson($rootMetadata)->trust();
 
-        $timestampMetadata = $this->prophesize(TimestampMetadata::class);
-        $timestampMetadata->getRole()->willReturn('unknown')->shouldBeCalled();
+        $timestampMetadata = $this->createMock(TimestampMetadata::class);
+        $timestampMetadata->expects($this->atLeastOnce())
+            ->method('getRole')
+            ->willReturn('unknown');
 
         $this->expectException(NotFoundException::class);
         $this->expectExceptionMessage("role not found: unknown");
         SignatureVerifier::createFromRootMetadata($rootMetadata)
-            ->checkSignatures($timestampMetadata->reveal());
+            ->checkSignatures($timestampMetadata);
     }
 }

--- a/tests/Unit/FileStorageTest.php
+++ b/tests/Unit/FileStorageTest.php
@@ -3,7 +3,6 @@
 namespace Tuf\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
 use Tuf\Client\DurableStorage\FileStorage;
 use Tuf\Metadata\MetadataBase;
 use Tuf\Metadata\RootMetadata;
@@ -16,8 +15,6 @@ use Tuf\Metadata\TimestampMetadata;
  */
 class FileStorageTest extends TestCase
 {
-    use ProphecyTrait;
-
     /**
      * Tests creating a FileStorage object with an invalid directory.
      *


### PR DESCRIPTION
We are only using Prophecy in two places in our tests; the rest of the time, we're using PHPUnit's mocking framework. Since Prophecy necessitates additional dependencies and has some incompatibilities with PHP 8.2 (you can't set a mock's constructor arguments without triggering a language-level deprecation), I don't think we should be using two mocking frameworks. Let's remove Prophecy and rely only on PHPUnit.