### PR TITLE
Remove every instance of `@return void`

### DIFF
--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -196,7 +196,6 @@ class Updater
      * @param \Tuf\Metadata\RootMetadata $rootData
      *   The current root metadata.
      *
-     * @return void
      *@throws \Tuf\Exception\Attack\FreezeAttackException
      *   Throw if a freeze attack is detected.
      * @throws \Tuf\Exception\Attack\RollbackAttackException

--- a/src/Metadata/ConstraintsTrait.php
+++ b/src/Metadata/ConstraintsTrait.php
@@ -27,8 +27,6 @@ trait ConstraintsTrait
      * @param \Symfony\Component\Validator\Constraints\Collection $constraints
      *   Th constraints collection for validation.
      *
-     * @return void
-     *
      * @throws \Tuf\Exception\MetadataException
      *    Thrown if validation fails.
      */

--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -209,8 +209,6 @@ abstract class MetadataBase
      *
      * @param boolean $allowUntrustedAccess
      *   Whether this method should access even if the metadata is not trusted.
-     *
-     * @return void
      */
     public function ensureIsTrusted(bool $allowUntrustedAccess = false): void
     {

--- a/src/Metadata/Verifier/TrustedAuthorityTrait.php
+++ b/src/Metadata/Verifier/TrustedAuthorityTrait.php
@@ -38,8 +38,6 @@ trait TrustedAuthorityTrait
      *
      * @throws \Tuf\Exception\MetadataException
      *   Thrown if the new metadata object cannot be verified.
-     *
-     * @return void
      */
     protected function checkAgainstHashesFromTrustedAuthority(MetadataBase $untrustedMetadata): void
     {
@@ -63,8 +61,6 @@ trait TrustedAuthorityTrait
      *
      * @throws \Tuf\Exception\MetadataException
      *   Thrown if the new metadata object cannot be verified.
-     *
-     * @return void
      */
     protected function checkAgainstVersionFromTrustedAuthority(MetadataBase $untrustedMetadata): void
     {

--- a/src/Metadata/Verifier/VerifierBase.php
+++ b/src/Metadata/Verifier/VerifierBase.php
@@ -51,8 +51,6 @@ abstract class VerifierBase
      * @param \Tuf\Metadata\MetadataBase $untrustedMetadata
      *     The untrusted metadata.
      *
-     * @return void
-     *
      * @throws \Tuf\Exception\Attack\RollbackAttackException
      *     Thrown if a potential rollback attack is detected.
      */

--- a/tests/Metadata/MetaDataBaseTest.php
+++ b/tests/Metadata/MetaDataBaseTest.php
@@ -54,8 +54,6 @@ abstract class MetadataBaseTest extends TestCase
      * @param string $json
      *   The json string.
      *
-     * @return void
-     *
      * @throws \Tuf\Exception\MetadataException
      *   If validation fails.
      */
@@ -66,8 +64,6 @@ abstract class MetadataBaseTest extends TestCase
      *
      * @param string $validJson
      *   The valid json key from $this->clientStorage.
-     *
-     * @return void
      *
      * @dataProvider providerValidMetadata
      */
@@ -99,8 +95,6 @@ abstract class MetadataBaseTest extends TestCase
 
     /**
      * Tests that validation fails on invalid type.
-     *
-     *  @return void
      */
     public function testInvalidType(): void
     {
@@ -121,8 +115,6 @@ abstract class MetadataBaseTest extends TestCase
 
     /**
      * @covers ::getRole
-     *
-     *  @return void
      */
     public function testGetRole(): void
     {
@@ -137,8 +129,6 @@ abstract class MetadataBaseTest extends TestCase
      *   Expires date to test.
      * @param boolean $valid
      *   Whether it's valid.
-     *
-     *  @return void
      *
      * @dataProvider providerExpires
      */
@@ -162,8 +152,6 @@ abstract class MetadataBaseTest extends TestCase
      *   Spec version to test.
      * @param boolean $valid
      *   Whether it's valid.
-     *
-     *  @return void
      *
      * @dataProvider providerSpecVersion
      */
@@ -190,8 +178,6 @@ abstract class MetadataBaseTest extends TestCase
      *
      *   A different exception message to expect.
      *
-     * @return void
-     *
      * @dataProvider providerExpectedField
      */
     public function testMissingField(string $expectedField, string $exception = null): void
@@ -217,8 +203,6 @@ abstract class MetadataBaseTest extends TestCase
      *   The name of the field. Nested fields indicated with ":".
      * @param mixed $value
      *   The value to set.
-     *
-     * @return void
      *
      * @dataProvider providerOptionalFields
      */
@@ -268,8 +252,6 @@ abstract class MetadataBaseTest extends TestCase
      *   Ordered keys to the value to unset.
      * @param array $data
      *   The array to modify.
-     *
-     * @return void
      */
     protected function nestedUnset(array $keys, array &$data): void
     {
@@ -289,8 +271,6 @@ abstract class MetadataBaseTest extends TestCase
      *
      * @param string $expectedType
      *   The type of the field.
-     *
-     * @return void
      *
      * @dataProvider providerValidField
      */

--- a/tests/Metadata/RootMetadataTest.php
+++ b/tests/Metadata/RootMetadataTest.php
@@ -73,8 +73,6 @@ class RootMetadataTest extends MetadataBaseTest
      * @param string $missingRole
      *   The required role to test.
      *
-     * @return void
-     *
      * @dataProvider providerRequireRoles
      */
     public function testRequiredRoles(string $missingRole): void
@@ -123,8 +121,6 @@ class RootMetadataTest extends MetadataBaseTest
 
     /**
      * Tests that an unknown role name is not allowed.
-     *
-     * @return void
      */
     public function testInvalidRoleName(): void
     {
@@ -139,8 +135,6 @@ class RootMetadataTest extends MetadataBaseTest
 
     /**
      * @covers ::supportsConsistentSnapshots
-     *
-     * @return void
      */
     public function testSupportsConsistentSnapshots(): void
     {

--- a/tests/Metadata/TargetsMetadataTest.php
+++ b/tests/Metadata/TargetsMetadataTest.php
@@ -34,9 +34,6 @@ class TargetsMetadataTest extends MetadataBaseTest
     /**
      * @covers ::getHashes
      * @covers ::getLength
-     *
-     * @return void
-     *   Describe the void.
      */
     public function testGetHashesAndLength(): void
     {

--- a/tests/Metadata/UntrustedExceptionTrait.php
+++ b/tests/Metadata/UntrustedExceptionTrait.php
@@ -14,8 +14,6 @@ trait UntrustedExceptionTrait
      *   The arguments for the method.
      *
      * @dataProvider providerUntrustedException
-     *
-     * @return void
      */
     public function testUntrustedException(string $method, array $args = []): void
     {

--- a/tests/TestHelpers/UtilsTrait.php
+++ b/tests/TestHelpers/UtilsTrait.php
@@ -54,8 +54,6 @@ trait UtilsTrait
      *   The array to modify.
      * @param mixed $newValue
      *   The new value to set.
-     *
-     * @return void
      */
     protected static function nestedChange(array $keys, array &$data, $newValue): void
     {

--- a/tests/Unit/Client/VerifierTest.php
+++ b/tests/Unit/Client/VerifierTest.php
@@ -16,8 +16,6 @@ class VerifierTest extends TestCase
      * Tests that no rollback attack is flagged when one is not performed.
      *
      * @covers ::checkRollbackAttack
-     *
-     * @return void
      */
     public function testCheckRollbackAttackNoAttack(): void
     {
@@ -68,8 +66,6 @@ class VerifierTest extends TestCase
      * Tests that the correct exception is thrown in case of a rollback attack.
      *
      * @covers ::checkRollbackAttack
-     *
-     * @return void
      */
     public function testCheckRollbackAttack(): void
     {
@@ -120,8 +116,6 @@ class VerifierTest extends TestCase
      * § 5.3.5
      *
      * @covers ::checkRollbackAttack
-     *
-     * @return void
      */
     public function testCheckRollbackAttackAttackExpectedVersion(): void
     {
@@ -168,8 +162,6 @@ class VerifierTest extends TestCase
      * Tests that no freeze attack is flagged when the data has not expired.
      *
      * @covers ::checkFreezeAttack
-     *
-     * @return void
      */
     public function testCheckFreezeAttackNoAttack(): void
     {
@@ -210,8 +202,6 @@ class VerifierTest extends TestCase
      * § 5.4.4
      * § 5.5.6
      * @covers ::checkFreezeAttack
-     *
-     * @return void
      */
     public function testCheckFreezeAttackAttack(): void
     {


### PR DESCRIPTION
`@return void` is a contradiction in terms and it has always irked me that our code base is littered with them. This PR removes all of them.