### PR TITLE
Remove DelegatedRole::isTerminating() in favor of read-only property

### DIFF
--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -436,7 +436,7 @@ class Updater
             if ($delegatedRole->matchesPath($target)) {
                 $delegatedRoles[] = $delegatedRole;
 
-                if ($delegatedRole->isTerminating()) {
+                if ($delegatedRole->terminating) {
                     break;
                 }
             }
@@ -471,7 +471,7 @@ class Updater
 
             // If $delegatedRole is terminating then we do not search any of the next delegated roles after it
             // in the delegations from $targetsMetadata.
-            if ($delegatedRole->isTerminating()) {
+            if ($delegatedRole->terminating) {
                 $terminated = true;
                 // § 5.6.7.2.1
                 // If the role is terminating then abort searching for a target.

--- a/src/DelegatedRole.php
+++ b/src/DelegatedRole.php
@@ -17,14 +17,6 @@ use Tuf\Exception\MetadataException;
 class DelegatedRole extends Role
 {
     /**
-     * @return bool
-     */
-    public function isTerminating(): bool
-    {
-        return $this->terminating;
-    }
-
-    /**
      * DelegatedRole constructor.
      *
      * @param string $name
@@ -34,7 +26,7 @@ class DelegatedRole extends Role
      * @param array|null $pathHashPrefixes
      * @param bool $terminating
      */
-    private function __construct(string $name, int $threshold, array $keyIds, protected ?array $paths, protected ?array $pathHashPrefixes, protected bool $terminating)
+    private function __construct(string $name, int $threshold, array $keyIds, protected ?array $paths, protected ?array $pathHashPrefixes, public readonly bool $terminating)
     {
         parent::__construct($name, $threshold, $keyIds);
     }

--- a/tests/Unit/DelegatedRoleTest.php
+++ b/tests/Unit/DelegatedRoleTest.php
@@ -25,7 +25,7 @@ class DelegatedRoleTest extends RoleTest
     public function testCreateFromMetadata(): void
     {
         parent::testCreateFromMetadata();
-        self::assertFalse($this->role->isTerminating());
+        self::assertFalse($this->role->terminating);
     }
 
     /**


### PR DESCRIPTION
Forgot to do this as part of #367. :)