### PR TITLE
Consistently use CanonicalJsonTrait in our code base

### DIFF
--- a/src/CanonicalJsonTrait.php
+++ b/src/CanonicalJsonTrait.php
@@ -43,7 +43,7 @@ trait CanonicalJsonTrait
      */
     protected static function decodeJson(string $data): array
     {
-        return json_decode($data, true, 512, JSON_THROW_ON_ERROR);
+        return json_decode($data, true, flags: JSON_THROW_ON_ERROR);
     }
 
     /**

--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -98,7 +98,7 @@ abstract class MetadataBase
      */
     public static function createFromJson(string $json): static
     {
-        $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        $data = static::decodeJson($json);
         static::validate($data, new Collection(static::getConstraints()));
         return new static($data, $json);
     }

--- a/tests/Metadata/MetaDataBaseTest.php
+++ b/tests/Metadata/MetaDataBaseTest.php
@@ -104,13 +104,13 @@ abstract class MetadataBaseTest extends TestCase
      */
     public function testInvalidType(): void
     {
-        $metadata = json_decode($this->clientStorage->read($this->validJson), true);
+        $metadata = static::decodeJson($this->clientStorage->read($this->validJson));
         $metadata['signed']['_type'] = 'invalid_type_value';
         $expectedMessage = preg_quote("Array[signed][_type]", '/');
         $expectedMessage .= ".*This value should be equal to \"{$this->expectedType}\"";
         $this->expectException(MetadataException::class);
         $this->expectExceptionMessageMatches("/$expectedMessage/s");
-        static::callCreateFromJson(json_encode($metadata));
+        static::callCreateFromJson(static::encodeJson($metadata));
     }
 
     public function testGetType(): void
@@ -144,7 +144,7 @@ abstract class MetadataBaseTest extends TestCase
      */
     public function testExpires(string $expires, bool $valid): void
     {
-        $metadata = json_decode($this->clientStorage->read($this->validJson), true);
+        $metadata = static::decodeJson($this->clientStorage->read($this->validJson));
         $metadata['signed']['expires'] = $expires;
         if (!$valid) {
             $expectedMessage = preg_quote('Array[signed][expires]', '/');
@@ -152,7 +152,7 @@ abstract class MetadataBaseTest extends TestCase
             $this->expectException(MetadataException::class);
             $this->expectExceptionMessageMatches("/$expectedMessage/s");
         }
-        static::callCreateFromJson(json_encode($metadata));
+        static::callCreateFromJson(static::encodeJson($metadata));
     }
 
     /**
@@ -169,7 +169,7 @@ abstract class MetadataBaseTest extends TestCase
      */
     public function testSpecVersion(string $version, bool $valid): void
     {
-        $metadata = json_decode($this->clientStorage->read($this->validJson), true);
+        $metadata = static::decodeJson($this->clientStorage->read($this->validJson));
         $metadata['signed']['spec_version'] = $version;
         if (!$valid) {
             $expectedMessage = preg_quote('Array[signed][spec_version]', '/');
@@ -177,7 +177,7 @@ abstract class MetadataBaseTest extends TestCase
             $this->expectException(MetadataException::class);
             $this->expectExceptionMessageMatches("/$expectedMessage/s");
         }
-        static::callCreateFromJson(json_encode($metadata));
+        static::callCreateFromJson(static::encodeJson($metadata));
     }
 
     /**
@@ -196,11 +196,11 @@ abstract class MetadataBaseTest extends TestCase
      */
     public function testMissingField(string $expectedField, string $exception = null): void
     {
-        $metadata = json_decode($this->clientStorage->read($this->validJson), true);
+        $metadata = static::decodeJson($this->clientStorage->read($this->validJson));
         $keys = explode(':', $expectedField);
         $fieldName = preg_quote('Array[' . implode('][', $keys) . ']', '/');
         $this->nestedUnset($keys, $metadata);
-        $json = json_encode($metadata);
+        $json = static::encodeJson($metadata);
         $this->expectException(MetadataException::class);
         if ($exception) {
             $this->expectExceptionMessageMatches("/$exception/s");
@@ -226,7 +226,7 @@ abstract class MetadataBaseTest extends TestCase
     {
         $optionalField = explode(':', $optionalField);
 
-        $metadata = json_decode($this->clientStorage->read($this->validJson), true);
+        $metadata = static::decodeJson($this->clientStorage->read($this->validJson));
         static::nestedChange($optionalField, $metadata, $value);
         $this->assertDataIsValid($metadata);
 
@@ -244,7 +244,7 @@ abstract class MetadataBaseTest extends TestCase
      */
     private function assertDataIsValid(array $data): void
     {
-        $json = json_encode($data);
+        $json = static::encodeJson($data);
         static::assertInstanceOf(MetadataBase::class, static::callCreateFromJson($json));
     }
 
@@ -296,7 +296,7 @@ abstract class MetadataBaseTest extends TestCase
      */
     public function testInvalidField(string $expectedField, string $expectedType): void
     {
-        $metadata = json_decode($this->clientStorage->read($this->validJson), true);
+        $metadata = static::decodeJson($this->clientStorage->read($this->validJson));
         $keys = explode(':', $expectedField);
 
         switch ($expectedType) {
@@ -319,7 +319,7 @@ abstract class MetadataBaseTest extends TestCase
         }
 
         static::nestedChange($keys, $metadata, $newValue);
-        $json = json_encode($metadata);
+        $json = static::encodeJson($metadata);
         $this->expectException(MetadataException::class);
         $this->expectExceptionMessageMatches("/This value should be of type " . preg_quote($expectedType) . "/s");
         static::callCreateFromJson($json);
@@ -422,7 +422,7 @@ abstract class MetadataBaseTest extends TestCase
     protected function getFixtureNestedArrayFirstKey(string $fixtureName, array $nestedKeys): string
     {
         $realPath = static::getFixturePath('Delegated/consistent', "client/$fixtureName.json", false);
-        $data = json_decode(file_get_contents($realPath), true);
+        $data = static::decodeJson(file_get_contents($realPath));
         foreach ($nestedKeys as $nestedKey) {
             $data = $data[$nestedKey];
         }

--- a/tests/Metadata/RootMetadataTest.php
+++ b/tests/Metadata/RootMetadataTest.php
@@ -83,9 +83,9 @@ class RootMetadataTest extends MetadataBaseTest
         $expectedMessage = preg_quote("Array[signed][roles][$missingRole]:", '/');
         $expectedMessage .= '.*This field is missing';
         $this->expectExceptionMessageMatches("/$expectedMessage/s");
-        $data = json_decode($this->clientStorage->read($this->validJson), true);
+        $data = static::decodeJson($this->clientStorage->read($this->validJson));
         unset($data['signed']['roles'][$missingRole]);
-        static::callCreateFromJson(json_encode($data));
+        static::callCreateFromJson(static::encodeJson($data));
     }
 
     /**
@@ -132,9 +132,9 @@ class RootMetadataTest extends MetadataBaseTest
         $expectedMessage = preg_quote("Array[signed][roles][super_root]:", '/');
         $expectedMessage .= '.*This field was not expected';
         $this->expectExceptionMessageMatches("/$expectedMessage/s");
-        $data = json_decode($this->clientStorage->read($this->validJson), true);
+        $data = static::decodeJson($this->clientStorage->read($this->validJson));
         $data['signed']['roles']['super_root'] = $data['signed']['roles']['root'];
-        static::callCreateFromJson(json_encode($data));
+        static::callCreateFromJson(static::encodeJson($data));
     }
 
     /**
@@ -144,11 +144,11 @@ class RootMetadataTest extends MetadataBaseTest
      */
     public function testSupportsConsistentSnapshots(): void
     {
-        $data = json_decode($this->clientStorage->read($this->validJson), true);
+        $data = static::decodeJson($this->clientStorage->read($this->validJson));
         foreach ([true, false] as $value) {
             $data['signed']['consistent_snapshot'] = $value;
             /** @var \Tuf\Metadata\RootMetadata $metadata */
-            $metadata = static::callCreateFromJson(json_encode($data));
+            $metadata = static::callCreateFromJson(static::encodeJson($data));
             $metadata->trust();
             $this->assertSame($value, $metadata->supportsConsistentSnapshots());
         }
@@ -175,7 +175,7 @@ class RootMetadataTest extends MetadataBaseTest
     public function testGetRoles(): void
     {
         $json = $this->clientStorage->read($this->validJson);
-        $data = json_decode($json, true);
+        $data = static::decodeJson($json);
         /** @var \Tuf\Metadata\RootMetadata $metadata */
         $metadata = static::callCreateFromJson($json);
         $metadata->trust();
@@ -194,13 +194,13 @@ class RootMetadataTest extends MetadataBaseTest
 
     public function testInvalidKeyType(): void
     {
-        $metadata = json_decode($this->clientStorage->read($this->validJson), true);
+        $metadata = static::decodeJson($this->clientStorage->read($this->validJson));
         $keyId = key($metadata['signed']['keys']);
         $metadata['signed']['keys'][$keyId]['keytype'] = 'invalid key type';
         $expectedMessage = preg_quote("Array[signed][keys][$keyId][keytype]", '/');
         $expectedMessage .= ".*This value should be identical to string \"ed25519\"";
         $this->expectException(MetadataException::class);
         $this->expectExceptionMessageMatches("/$expectedMessage/s");
-        static::callCreateFromJson(json_encode($metadata));
+        static::callCreateFromJson(static::encodeJson($metadata));
     }
 }

--- a/tests/Metadata/TargetsMetadataTest.php
+++ b/tests/Metadata/TargetsMetadataTest.php
@@ -42,7 +42,7 @@ class TargetsMetadataTest extends MetadataBaseTest
     {
         $json = $this->clientStorage->read($this->validJson);
         $metadata = TargetsMetadata::createFromJson($json);
-        $json = json_decode($json, true);
+        $json = static::decodeJson($json);
 
         $target = key($json['signed']['targets']);
         $this->assertSame($metadata->getHashes($target), $json['signed']['targets'][$target]['hashes']);
@@ -71,7 +71,7 @@ class TargetsMetadataTest extends MetadataBaseTest
     {
         $json = $this->clientStorage->read($this->validJson);
         $metadata = TargetsMetadata::createFromJson($json);
-        $json = json_decode($json, true);
+        $json = static::decodeJson($json);
 
         $target = key($json['signed']['targets']);
         $this->assertTrue($metadata->hasTarget($target));
@@ -150,7 +150,7 @@ class TargetsMetadataTest extends MetadataBaseTest
         $json = $this->clientStorage->read($this->validJson);
         /** @var \Tuf\Metadata\TargetsMetadata $metadata */
         $metadata = TargetsMetadata::createFromJson($json);
-        $json = json_decode($json, true);
+        $json = static::decodeJson($json);
         $keys = $metadata->getDelegatedKeys();
         $expectedKeys = $json['signed']['delegations']['keys'];
         self::assertCount(count($expectedKeys), $keys);
@@ -170,7 +170,7 @@ class TargetsMetadataTest extends MetadataBaseTest
         $json = $this->clientStorage->read($this->validJson);
         /** @var TargetsMetadata $metadata */
         $metadata = TargetsMetadata::createFromJson($json);
-        $json = json_decode($json, true);
+        $json = static::decodeJson($json);
         $delegatedRoles = $metadata->getDelegatedRoles();
         $expectedRoles = $json['signed']['delegations']['roles'];
         self::assertCount(1, $expectedRoles);
@@ -204,12 +204,12 @@ class TargetsMetadataTest extends MetadataBaseTest
     public function testDuplicateDelegatedRoleNames(): void
     {
         $json = $this->clientStorage->read($this->validJson);
-        $data = json_decode($json, true);
+        $data = static::decodeJson($json);
 
         $this->assertNotEmpty($data['signed']['delegations']['roles']);
         // Duplicating a role should raise a validation exception.
         $data['signed']['delegations']['roles'][] = $data['signed']['delegations']['roles'][0];
-        $json = json_encode($data);
+        $json = static::encodeJson($data);
 
         $this->expectException(MetadataException::class);
         $this->expectExceptionMessage('Delegated role names must be unique.');

--- a/tests/Unit/CanonicalJsonTraitTest.php
+++ b/tests/Unit/CanonicalJsonTraitTest.php
@@ -18,8 +18,8 @@ class CanonicalJsonTraitTest extends TestCase
     public function testSort(): void
     {
         $fixturesDirectory = __DIR__ . '/../../fixtures/json';
-        $sortedData = json_decode(file_get_contents("$fixturesDirectory/sorted.json"), true, 512, JSON_THROW_ON_ERROR);
-        $unsortedData = json_decode(file_get_contents("$fixturesDirectory/unsorted.json"), true, 512, JSON_THROW_ON_ERROR);
+        $sortedData = static::decodeJson(file_get_contents("$fixturesDirectory/sorted.json"));
+        $unsortedData = static::decodeJson(file_get_contents("$fixturesDirectory/unsorted.json"));
         static::sortKeys($unsortedData);
         $this->assertSame($unsortedData, $sortedData);
 


### PR DESCRIPTION
Our code base is littered with examples of us calling `json_encode()` and `json_decode()` directly, even in places that use `CanonicalJsonTrait`.

Considering how it's very important than JSON be encoded and decoded consistently (one might even say canonically) in PHP-TUF, it makes sense to always use the `CanonicalJsonTrait` methods unless there's a specific reason not to.