### PR TITLE
Allow all CI workflows to be triggered manually

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
   schedule:
     # Run this workflow at 3 AM UTC every day.
     - cron: '0 3 * * *'
+  workflow_dispatch:
 
 env:
   COMPOSER_FLAGS: "--ansi --no-interaction --no-progress --prefer-dist --optimize-autoloader"

--- a/.github/workflows/drupal-recommended-project.yml
+++ b/.github/workflows/drupal-recommended-project.yml
@@ -7,6 +7,7 @@ on:
     branches: [ main ]
   schedule:
     - cron: '0 3 * * *'
+  workflow_dispatch:
 
 jobs:
   composer-project:


### PR DESCRIPTION
I need this now, so that I can confirm that PHP-TUF is working before I start hacking on the plugin again.