### PR TITLE
Update TUF spec to 1.0.33

### DIFF
--- a/.github/workflows/specification-version-check.yml
+++ b/.github/workflows/specification-version-check.yml
@@ -11,4 +11,4 @@ jobs:
       issues: write
     uses: theupdateframework/specification/.github/workflows/check-latest-spec-version.yml@master
     with:
-      tuf-version: "v1.0.32" # Should be updated to the version the project supports either manually or extracted automatically. You can see how python-tuf did that as an example.
+      tuf-version: "v1.0.33" # Should be updated to the version the project supports either manually or extracted automatically. You can see how python-tuf did that as an example.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It should currently only be used for testing, development and feedback.
 PHP-TUF is a PHP implementation of [The Update Framework
 (TUF)](https://theupdateframework.io/) to provide signing and verification for
 secure PHP application updates. [Read the TUF
-specification](https://theupdateframework.github.io/specification/v1.0.32)
+specification](https://theupdateframework.github.io/specification/v1.0.33)
 for more information on how TUF is intended to work and the security it
 provides.
 
@@ -74,5 +74,5 @@ dependency information](DEPENDENCIES.md).
   * [Code Documentation: Main Index](https://github.com/theupdateframework/tuf/blob/develop/tuf/README.md)
   * [CLI](https://github.com/theupdateframework/tuf/blob/develop/docs/CLI.md)
   * [Python API Readme](https://github.com/theupdateframework/tuf/blob/develop/tuf/client/README.md)
-* [TUF Specification v1.0.32](https://theupdateframework.github.io/specification/v1.0.32)
+* [TUF Specification v1.0.33](https://theupdateframework.github.io/specification/v1.0.33)
 * [PIP + TUF Integration](https://www.python.org/dev/peps/pep-0458/)

--- a/src/Client/SignatureVerifier.php
+++ b/src/Client/SignatureVerifier.php
@@ -64,7 +64,7 @@ final class SignatureVerifier
         $verifiedKeySignatures = [];
 
         foreach ($metadata->signatures as $signature) {
-            // Don't allow the same key to be counted twice.
+            // Per the spec, the same key can't be counted more than once.
             if ($role->isKeyIdAcceptable($signature['keyid']) && $this->verifySingleSignature($metadata->toCanonicalJson(), $signature)) {
                 $verifiedKeySignatures[$signature['keyid']] = true;
             }
@@ -134,7 +134,7 @@ final class SignatureVerifier
      * @param string $keyId
      * @param \Tuf\Key $key
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.32#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.33#document-formats
      */
     public function addKey(string $keyId, Key $key): void
     {

--- a/src/Client/SignatureVerifier.php
+++ b/src/Client/SignatureVerifier.php
@@ -64,8 +64,8 @@ final class SignatureVerifier
         $verifiedKeySignatures = [];
 
         foreach ($metadata->signatures as $signature) {
-            // Per the spec, the same key can't be counted more than once.
             if ($role->isKeyIdAcceptable($signature['keyid']) && $this->verifySingleSignature($metadata->toCanonicalJson(), $signature)) {
+                // Per the spec, the same key can't be counted more than once.
                 $verifiedKeySignatures[$signature['keyid']] = true;
             }
             // @todo Determine if we should check all signatures and warn for

--- a/src/Key.php
+++ b/src/Key.php
@@ -38,7 +38,7 @@ final class Key
      *
      * @return static
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.32#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.33#document-formats
      */
     public static function createFromMetadata(array $keyInfo): self
     {
@@ -59,7 +59,7 @@ final class Key
      * @return string
      *     The key ID in hex format for the key metadata hashed using sha256.
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.32#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.33#document-formats
      *
      * @todo https://github.com/php-tuf/php-tuf/issues/56
      */

--- a/src/Role.php
+++ b/src/Role.php
@@ -35,7 +35,7 @@ class Role
      *
      * @return static
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.32#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.33#document-formats
      */
     public static function createFromMetadata(array $roleInfo, string $name): Role
     {


### PR DESCRIPTION
Fixes #352.

I had to carefully read the spec difference (https://github.com/theupdateframework/specification/compare/v1.0.32...v1.0.33) to determine that, in fact, we're already compliant, based on this code in `SignatureVerifier::checkSignatures()`:

```
            if ($role->isKeyIdAcceptable($signature['keyid']) && $this->verifySingleSignature($metadata->toCanonicalJson(), $signature)) {
                $verifiedKeySignatures[$signature['keyid']] = true;
            }
```

If I understand it correctly, the spec is simply being explicit that the same key cannot count more than once. We were already doing that.

So I think we're good here!