### PR TITLE
Temporarily restore keyid_hash_algorithms for backwards compatibility with securesystemslib

### DIFF
--- a/src/Key.php
+++ b/src/Key.php
@@ -74,8 +74,8 @@ final class Key
             ],
             // This field is no longer part of the TUF spec, but it's here for backwards compatibility
             // with securesystemslib 0.30.0 and older (a Python package used by Rugged, and possibly
-            // others, to generate server-side TUF metadata). We can remove this once ### is fixed
-            // and deployed.
+            // others, to generate server-side TUF metadata). We can remove this once
+            // https://gitlab.com/rugged/rugged/-/issues/192 is fixed and deployed.
             // @see \Tuf\Tests\FixtureBuilder\Key::toArray()
             'keyid_hash_algorithms' => ['sha256', 'sha512'],
         ]);

--- a/src/Key.php
+++ b/src/Key.php
@@ -72,6 +72,12 @@ final class Key
             'keyval' => [
                 'public' => $this->public,
             ],
+            // This field is no longer part of the TUF spec, but it's here for backwards compatibility
+            // with securesystemslib 0.30.0 and older (a Python package used by Rugged, and possibly
+            // others, to generate server-side TUF metadata). We can remove this once ### is fixed
+            // and deployed.
+            // @see \Tuf\Tests\FixtureBuilder\Key::toArray()
+            'keyid_hash_algorithms' => ['sha256', 'sha512'],
         ]);
         return hash('sha256', $canonical);
     }

--- a/tests/FixtureBuilder/Key.php
+++ b/tests/FixtureBuilder/Key.php
@@ -56,14 +56,15 @@ final class Key
             'keyval' => [
                 'public' => sodium_bin2hex($this->publicKey),
             ],
-            // @see \Tuf\Key::getComputedKeyId()
-            'keyid_hash_algorithms' => ['sha256', 'sha512'],
         ];
     }
 
     public function id(): string
     {
-        return hash('sha256', self::encodeJson($this->toArray()));
+        $value = $this->toArray();
+        // @see \Tuf\Key::getComputedKeyId()
+        $value['keyid_hash_algorithms'] = ['sha256', 'sha512'];
+        return hash('sha256', self::encodeJson($value));
     }
 
     /**

--- a/tests/FixtureBuilder/Key.php
+++ b/tests/FixtureBuilder/Key.php
@@ -56,6 +56,8 @@ final class Key
             'keyval' => [
                 'public' => sodium_bin2hex($this->publicKey),
             ],
+            // @see \Tuf\Key::getComputedKeyId()
+            'keyid_hash_algorithms' => ['sha256', 'sha512'],
         ];
     }
 

--- a/tests/Unit/KeyTest.php
+++ b/tests/Unit/KeyTest.php
@@ -26,6 +26,8 @@ class KeyTest extends TestCase
         self::assertSame('ed25519', $key->type);
         self::assertSame('12345', $key->public);
         $keySortedCanonicalStruct = [
+            // @see \Tuf\Key::getComputedKeyId()
+            'keyid_hash_algorithms' => ['sha256', 'sha512'],
             'keytype' => 'ed25519',
             'keyval' => ['public' => '12345'],
             'scheme' => 'scheme-ed11111',


### PR DESCRIPTION
[securesystemslib still includes `keyid_hash_algorithms` when canonicalizing keys](https://github.com/secure-systems-lab/securesystemslib/blob/release-0.30.0/securesystemslib/keys.py#L435), which puts it at odds with the TUF spec, which removed all mention of `keyid_hash_algorithms`  (and which we removed accordingly in #369).

Rugged, and possibly other server-side TUF repository generators, [are using securesystemslib and therefore including `keyid_hash_algorithms` when key IDs are computed](https://gitlab.com/rugged/rugged/-/blob/main/rugged/commands/lib/verification_keys.py#L67). We need to be compatible with that. So, although it is not spec-compliant, we can hotfix this on our end until the correct fix lands in Rugged, which is for it to _explicitly_ remove `keyid_hash_algorithms` from the canonicalized key before hashing it.