### PR TITLE
Avoid recursively looking up the same delegated roles multiple times

### DIFF
--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -385,7 +385,7 @@ class Updater
     private function fetchAndVerifyTargetsMetadata(string $role): TargetsMetadata
     {
         if (isset($this->targetsMetadata[$role])) {
-          return $this->targetsMetadata[$role];
+            return $this->targetsMetadata[$role];
         }
         $fileInfo = $this->storage->getSnapshot()->getFileMetaInfo("$role.json");
         // § 5.6.1
@@ -438,7 +438,7 @@ class Updater
             $this->signatureVerifier->addKey($keyId, $delegatedKey);
         }
         if (!isset($this->delegatedRoles[$targetsMetadata])) {
-          $this->delegatedRoles[$targetsMetadata] = $targetsMetadata->getDelegatedRoles();
+            $this->delegatedRoles[$targetsMetadata] = $targetsMetadata->getDelegatedRoles();
         }
 
         $delegatedRoles = [];
@@ -455,7 +455,7 @@ class Updater
         }
 
         foreach ($delegatedRoles as $delegatedRole) {
-          $delegatedRoleName = $delegatedRole->name;
+            $delegatedRoleName = $delegatedRole->name;
             if (in_array($delegatedRoleName, $searchedRoles, true)) {
                 // § 5.6.7.1
                 // If this role has been visited before, skip it (to avoid cycles in the delegation graph).

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -76,6 +76,9 @@ class Updater
      */
     protected Repository $server;
 
+    /**
+     * @var array<string, PromiseInterface<TargetsMetadata>>
+     */
     private array $targetsMetadata = [];
 
     private \SplObjectStorage $delegatedRoles;
@@ -464,7 +467,8 @@ class Updater
 
             $this->signatureVerifier->addRole($delegatedRole);
             /** @var \Tuf\Metadata\TargetsMetadata $delegatedTargetsMetadata */
-            $delegatedTargetsMetadata = $this->fetchAndVerifyTargetsMetadata($delegatedRoleName)->wait();
+            $delegatedTargetsMetadata = $this->fetchAndVerifyTargetsMetadata($delegatedRoleName)
+                ->wait();
             if ($delegatedTargetsMetadata->hasTarget($target)) {
                 return $delegatedTargetsMetadata;
             }

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -417,6 +417,8 @@ class Updater
      * @param bool $terminated
      *   (optional) For internal recursive calls only. This will be set to true if a terminating delegation is found in
      *   the search.
+     * @param array $all_delegated_roles
+     *   (optional) For internal recursive calls only to avoid looking up the delegated roles every iteration.
      *
      *
      * @return \Tuf\Metadata\TargetsMetadata|null

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -171,7 +171,7 @@ class Updater
         $this->storage->save($newSnapshotData);
 
         // § 5.6
-        $this->fetchAndVerifyTargetsMetadata('targets');
+        $this->fetchAndVerifyTargetsMetadata('targets')->wait();
 
         $this->isRefreshed = true;
         return true;
@@ -393,15 +393,13 @@ class Updater
             ? $fileInfo['version']
             : null;
 
-        $return = $this->server->getTargets($targetsVersion, $role, $fileInfo['length'] ?? null)
+        return $this->targetsMetadata[$role] = $this->server->getTargets($targetsVersion, $role, $fileInfo['length'] ?? null)
           ->then(function (TargetsMetadata $newTargetsData) {
               $this->universalVerifier->verify(TargetsMetadata::TYPE, $newTargetsData);
               // § 5.5.6
               $this->storage->save($newTargetsData);
               return $newTargetsData;
           });
-        $this->targetsMetadata[$role] = $return;
-        return $this->targetsMetadata[$role];
     }
 
     /**

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -76,9 +76,9 @@ class Updater
      */
     protected Repository $server;
 
-    protected array $targetsMetadata = [];
+    private array $targetsMetadata = [];
 
-    protected \SplObjectStorage $delegatedRoles;
+    private \SplObjectStorage $delegatedRoles;
 
     /**
      * Updater constructor.
@@ -437,9 +437,7 @@ class Updater
         foreach ($targetsMetadata->getDelegatedKeys() as $keyId => $delegatedKey) {
             $this->signatureVerifier->addKey($keyId, $delegatedKey);
         }
-        if (!isset($this->delegatedRoles[$targetsMetadata])) {
-            $this->delegatedRoles[$targetsMetadata] = $targetsMetadata->getDelegatedRoles();
-        }
+        $this->delegatedRoles[$targetsMetadata] ??= $targetsMetadata->getDelegatedRoles();
 
         $delegatedRoles = [];
         foreach ($this->delegatedRoles[$targetsMetadata] as $delegatedRole) {

--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -382,7 +382,7 @@ class Updater
      * @return \GuzzleHttp\Promise\PromiseInterface<\Tuf\Metadata\TargetsMetadata>
      *   A promise wrapping the verified metadata for the role.
      */
-    private function fetchAndVerifyTargetsMetadata(string $role): TargetsMetadata
+    private function fetchAndVerifyTargetsMetadata(string $role): PromiseInterface
     {
         if (isset($this->targetsMetadata[$role])) {
             return $this->targetsMetadata[$role];
@@ -400,7 +400,7 @@ class Updater
               $this->storage->save($newTargetsData);
               return $newTargetsData;
           });
-        $this->targetsMetadata[$role] = $return->wait();
+        $this->targetsMetadata[$role] = $return;
         return $this->targetsMetadata[$role];
     }
 
@@ -466,7 +466,7 @@ class Updater
 
             $this->signatureVerifier->addRole($delegatedRole);
             /** @var \Tuf\Metadata\TargetsMetadata $delegatedTargetsMetadata */
-            $delegatedTargetsMetadata = $this->fetchAndVerifyTargetsMetadata($delegatedRoleName);
+            $delegatedTargetsMetadata = $this->fetchAndVerifyTargetsMetadata($delegatedRoleName)->wait();
             if ($delegatedTargetsMetadata->hasTarget($target)) {
                 return $delegatedTargetsMetadata;
             }


### PR DESCRIPTION
Updater::searchDelegatedRolesForTarget() calls itself recursively, however it calculates the full list of delegated roles for 'bins' every time. This is causing severe CPU and memory issues when testing locally with Drupal core.

An improvement is to store the delegated roles in a class property.

For me this leads to approximately a 50% reduction in both function calls and peak memory usage when profiling composer update with xhprof. It also removes about 15 http requests from Guzzle, because it was doing the full http request and everything else to build the list for 'bins' each time.



Before:

![Screenshot from 2025-05-01 12-05-48](https://github.com/user-attachments/assets/903c47c5-ed0a-43a1-bdd7-ea17773fe251)

![Screenshot from 2025-05-01 12-07-57](https://github.com/user-attachments/assets/d6579c0f-8044-49d7-a7b0-997230c38811)




After:

![Screenshot from 2025-05-01 12-13-21](https://github.com/user-attachments/assets/1e9e3efd-758b-4d3b-a2e0-cb0ccf36f87b)


![Screenshot from 2025-05-01 12-14-06](https://github.com/user-attachments/assets/5a9695c8-14a4-443e-989c-45551b72a97b)


