### PR TITLE
Ensure that createFromJson() only creates one object per json string.

### DIFF
--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -101,7 +101,7 @@ abstract class MetadataBase
      */
     public static function createFromJson(string $json): static
     {
-        $key = hash('xxh64', $json);
+        $key = hash('xxh3', $json);
         if (isset(static::$jsonCache[$key])) {
           return static::$jsonCache[$key];
         }

--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -47,6 +47,7 @@ abstract class MetadataBase
 
     public readonly int $version;
 
+    protected static array $jsonCache = [];
 
     /**
      * MetadataBase constructor.
@@ -100,9 +101,14 @@ abstract class MetadataBase
      */
     public static function createFromJson(string $json): static
     {
+        $key = hash('xxh64', $json);
+        if (isset(static::$jsonCache[$key])) {
+          return static::$jsonCache[$key];
+        }
         $data = static::decodeJson($json);
         static::validate($data, new Collection(static::getConstraints()));
-        return new static($data, $json);
+        static::$jsonCache[$key] =  new static($data, $json);
+        return static::$jsonCache[$key];
     }
 
     /**


### PR DESCRIPTION
This is a companion MR to https://github.com/php-tuf/php-tuf/pull/386

The combination of the two MRs, appears to almost entirely remove the php and cpu overhead of running php-tuf-enabled composer.

MetadataBase::createFromJson() is a static method that takes a JSON string, and returns an object representing the data.

When profiling a TUF-enabled Drupal core composer update, I can see MetadataBase::decodeJson() taking about 100mb of inclusive peak memory usage.

The same logic is run around 10 times on exactly the same JSON string each, this means we can reduce the overhead by about 90%.

Unfortunately given this is a static method and one that's called from various different places, the only easy way to add static caching was to add a real static variable to the class. There is probably a way this could be refactored to avoid that, but this would require someone more familiar with the php-tuf code base I think (or a lot more time, which I don't have).



Before:

![Screenshot from 2025-05-01 16-12-21](https://github.com/user-attachments/assets/55fbd86a-a3ae-4140-8e35-a49ceeb9d27f)


After:

![Screenshot from 2025-05-01 16-12-25](https://github.com/user-attachments/assets/18c895f7-1969-4fe9-8837-084cb54327e4)

