### PR TITLE
Fix deprecations in Symfony 7.3

### DIFF
--- a/src/Metadata/ConstraintsTrait.php
+++ b/src/Metadata/ConstraintsTrait.php
@@ -53,7 +53,7 @@ trait ConstraintsTrait
     {
         return [
             'hashes' => [
-                new Count(['min' => 1]),
+                new Count(min: 1),
               // The keys for 'hashes is not know but they all must be strings.
                 new All([
                     new Type('string'),
@@ -104,7 +104,7 @@ trait ConstraintsTrait
     {
         return [
             'keyids' => [
-                new Count(['min' => 1]),
+                new Count(min: 1),
                 // The keys for 'hashes is not know but they all must be strings.
                 new All([
                     new Type('string'),

--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -134,7 +134,7 @@ abstract class MetadataBase
                 ),
             ]),
             'signed' => new Required([
-                new Collection(static::getSignedCollectionOptions()),
+                new Collection(...static::getSignedCollectionOptions()),
             ]),
         ];
     }

--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -128,10 +128,10 @@ abstract class MetadataBase
                         ],
                     ]),
                 ]),
-                new Unique([
-                    'fields' => ['keyid'],
-                    'message' => 'Key IDs must be unique.',
-                ]),
+                new Unique(
+                    message: 'Key IDs must be unique.',
+                    fields: ['keyid'],
+                ),
             ]),
             'signed' => new Required([
                 new Collection(static::getSignedCollectionOptions()),

--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -115,7 +115,7 @@ abstract class MetadataBase
     {
         return [
             'signatures' => new Required([
-                new Count(['min' => 1]),
+                new Count(min: 1),
                 new All([
                     new Collection([
                         'keyid' => [

--- a/src/Metadata/MetadataBase.php
+++ b/src/Metadata/MetadataBase.php
@@ -154,7 +154,7 @@ abstract class MetadataBase
                     new EqualTo(static::TYPE),
                     new Type('string'),
                 ],
-                'expires' => new DateTime(['value' => \DateTimeInterface::ISO8601]),
+                'expires' => new DateTime(\DateTimeInterface::ISO8601),
                 // We only expect to work with major version 1.
                 'spec_version' => [
                     new NotBlank(),

--- a/src/Metadata/RootMetadata.php
+++ b/src/Metadata/RootMetadata.php
@@ -26,7 +26,7 @@ class RootMetadata extends MetadataBase
     {
         $options = parent::getSignedCollectionOptions();
         $options['fields']['keys'] = new Required([
-            new Count(['min' => 1]),
+            new Count(min: 1),
             new All([
                 static::getKeyConstraints(),
             ]),

--- a/src/Metadata/SnapshotMetadata.php
+++ b/src/Metadata/SnapshotMetadata.php
@@ -26,12 +26,7 @@ class SnapshotMetadata extends FileInfoMetadataBase
         $options['fields']['meta'] = new Required([
             new Count(min: 1),
             new All([
-                new Collection(
-                    [
-                        'fields' => static::getMetaPathConstraints(),
-                        'allowExtraFields' => true,
-                    ]
-                ),
+                new Collection(static::getMetaPathConstraints(), allowExtraFields: true),
             ]),
         ]);
         return $options;

--- a/src/Metadata/SnapshotMetadata.php
+++ b/src/Metadata/SnapshotMetadata.php
@@ -24,7 +24,7 @@ class SnapshotMetadata extends FileInfoMetadataBase
     {
         $options = parent::getSignedCollectionOptions();
         $options['fields']['meta'] = new Required([
-            new Count(['min' => 1]),
+            new Count(min: 1),
             new All([
                 new Collection(
                     [

--- a/src/Metadata/TargetsMetadata.php
+++ b/src/Metadata/TargetsMetadata.php
@@ -83,8 +83,8 @@ class TargetsMetadata extends MetadataBase
                 ]),
                 'roles' => new Required([
                     new All([
-                        new Collection([
-                            'fields' => [
+                        new Collection(
+                            [
                                 'name' => [
                                     new NotBlank(),
                                     new Type('string'),
@@ -105,7 +105,7 @@ class TargetsMetadata extends MetadataBase
                                     new Type('boolean'),
                                 ],
                             ] + static::getKeyidsConstraints() + static::getThresholdConstraints(),
-                        ]),
+                        ),
                     ]),
                     new Unique(
                         message: 'Delegated role names must be unique.',

--- a/src/Metadata/TargetsMetadata.php
+++ b/src/Metadata/TargetsMetadata.php
@@ -107,10 +107,10 @@ class TargetsMetadata extends MetadataBase
                             ] + static::getKeyidsConstraints() + static::getThresholdConstraints(),
                         ]),
                     ]),
-                    new Unique([
-                        'fields' => ['name'],
-                        'message' => 'Delegated role names must be unique.',
-                    ]),
+                    new Unique(
+                        message: 'Delegated role names must be unique.',
+                        fields: ['name'],
+                    ),
                 ]),
             ]),
         ]);

--- a/src/Metadata/TimestampMetadata.php
+++ b/src/Metadata/TimestampMetadata.php
@@ -24,7 +24,7 @@ class TimestampMetadata extends FileInfoMetadataBase
     {
         $options = parent::getSignedCollectionOptions();
         $options['fields']['meta'] = new Required([
-            new Count(['min' => 1]),
+            new Count(min: 1),
             new All([
                 new Collection([
                     'length' => new Optional([


### PR DESCRIPTION
Symfony 7.3 deprecated passing arrays of options to validation constraints, and wants named arguments instead. This is also supported by Symfony 6, so let's fix this to remove the deprecated behavior so CI can pass again.