### PR TITLE
Add targetsHash argument to ::matchesPath() to save recalculating.

### DIFF
--- a/src/Client/Updater.php
+++ b/src/Client/Updater.php
@@ -441,10 +441,11 @@ class Updater
         $this->delegatedRoles[$targetsMetadata] ??= $targetsMetadata->getDelegatedRoles();
 
         $delegatedRoles = [];
+        $targetHash = hash('sha256', $target);
         foreach ($this->delegatedRoles[$targetsMetadata] as $delegatedRole) {
             // Targets must match the paths of all roles in the delegation chain, so if the path does not match,
             // do not evaluate this role or any roles it delegates to.
-            if ($delegatedRole->matchesPath($target)) {
+            if ($delegatedRole->matchesPath($target, $targetHash)) {
                 $delegatedRoles[] = $delegatedRole;
 
                 if ($delegatedRole->terminating) {

--- a/src/DelegatedRole.php
+++ b/src/DelegatedRole.php
@@ -87,15 +87,17 @@ class DelegatedRole extends Role
      *
      * @param string $target
      *   The path of the target file.
+     * @param string $targetHash
+     *   The sha256 hash of the target.
      *
      * @return bool
      *   True if there is path match or no path criteria is set for the role, or
      *   false otherwise.
      */
-    public function matchesPath(string $target): bool
+    public function matchesPath(string $target, ?string $targetHash = NULL): bool
     {
         if (isset($this->pathHashPrefixes)) {
-            $targetHash = hash('sha256', $target);
+            $targetHash ??= hash('sha256', $target);
 
             foreach ($this->pathHashPrefixes as $prefix) {
                 if (str_starts_with($targetHash, $prefix)) {


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/c104cade-6336-454b-b03e-fc4f6ff3c80c)


After:

![image](https://github.com/user-attachments/assets/1cdb82cd-fd4d-42bc-bc9f-e41f3cf1285e)

![image](https://github.com/user-attachments/assets/db6b2a1a-e6f8-44f5-82c2-0f7b49f1a0d7)


This replaces approximately 8,000 calls to hash() with about 15 on my local install.