### PR TITLE
fix: #402 Ensure 'expires' in fixture data is generated as UTC

### DIFF
--- a/tests/Client/UpdaterTest.php
+++ b/tests/Client/UpdaterTest.php
@@ -1062,8 +1062,18 @@ abstract class UpdaterTest extends ClientTestBase
 
         // The length of the timestamp metadata is never known in advance, so it
         // is always downloaded with the maximum length.
-        $this->assertSame(Repository::$maxBytes, $this->serverFiles->maxBytes['timestamp.json'][0]);
-        $this->assertSame($expectedLength, $this->serverFiles->maxBytes[$downloadedFileName][0]);
+        $actual = $this->serverFiles->maxBytes['timestamp.json'][0];
+        $this->assertSame(
+            Repository::$maxBytes,
+            $actual,
+            sprintf('Expected timestamp.json to be %s bytes, got %s bytes.', Repository::$maxBytes, $actual),
+        );
+        $actual = $this->serverFiles->maxBytes[$downloadedFileName][0];
+        $this->assertSame(
+            $expectedLength,
+            $actual,
+            sprintf('Expected %s to be %s bytes, got %s bytes.', $downloadedFileName, $expectedLength, $actual),
+        );
     }
 
     /**

--- a/tests/FixtureBuilder/Fixture.php
+++ b/tests/FixtureBuilder/Fixture.php
@@ -52,7 +52,7 @@ class Fixture
 
         // By default, all metadata we generate should expire in a year. This
         // can be overridden for individual metadata objects.
-        $expires ??= new \DateTimeImmutable('+1 year');
+        $expires ??= new \DateTimeImmutable('+1 year', new \DateTimeZone('UTC'));
 
         $this->root = new Root($expires, [
             Key::fromStaticList(),

--- a/tests/FixtureBuilder/Payload.php
+++ b/tests/FixtureBuilder/Payload.php
@@ -159,8 +159,10 @@ abstract class Payload implements \Stringable
      */
     protected function toArray(): array
     {
+        $expires = $this->expires->format('Y-m-d\TH:i:sp');
+        assert(str_ends_with($expires, 'Z'), sprintf("'expires' datetime must end with Z (zero UTC offset). Actual value: %s", $expires));
         return [
-            'expires' => $this->expires->format('Y-m-d\TH:i:sp'),
+            'expires' => $expires,
             'spec_version' => '1.0.0',
             'version' => $this->version,
             '_type' => $this->name,


### PR DESCRIPTION
See #402 for context.