### PR TITLE
Remove redundant paragonie/sodium_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     "require": {
         "php": "^8.1",
         "ext-json": "*",
-        "paragonie/sodium_compat": "^1.13",
         "symfony/validator": "^6.1 || ^7",
         "guzzlehttp/psr7": "^2.4",
         "guzzlehttp/promises": "^2"


### PR DESCRIPTION
This package depends on `paragonie/sodium_compat: ^1.13`, but also `php: ^8.1`. Since `libsodium` was added in PHP 7.2, the dependency on `paragonie/sodium_compat` seems redundant?