### PR TITLE
fix: #404 Declare support for TUF spec v1.0.34

### DIFF
--- a/.github/workflows/specification-version-check.yml
+++ b/.github/workflows/specification-version-check.yml
@@ -11,4 +11,4 @@ jobs:
       issues: write
     uses: theupdateframework/specification/.github/workflows/check-latest-spec-version.yml@master
     with:
-      tuf-version: "v1.0.33" # Should be updated to the version the project supports either manually or extracted automatically. You can see how python-tuf did that as an example.
+      tuf-version: "v1.0.34" # Should be updated to the version the project supports either manually or extracted automatically. You can see how python-tuf did that as an example.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It should currently only be used for testing, development and feedback.
 PHP-TUF is a PHP implementation of [The Update Framework
 (TUF)](https://theupdateframework.io/) to provide signing and verification for
 secure PHP application updates. [Read the TUF
-specification](https://theupdateframework.github.io/specification/v1.0.33)
+specification](https://theupdateframework.github.io/specification/v1.0.34)
 for more information on how TUF is intended to work and the security it
 provides.
 
@@ -74,5 +74,5 @@ dependency information](DEPENDENCIES.md).
   * [Code Documentation: Main Index](https://github.com/theupdateframework/tuf/blob/develop/tuf/README.md)
   * [CLI](https://github.com/theupdateframework/tuf/blob/develop/docs/CLI.md)
   * [Python API Readme](https://github.com/theupdateframework/tuf/blob/develop/tuf/client/README.md)
-* [TUF Specification v1.0.33](https://theupdateframework.github.io/specification/v1.0.33)
+* [TUF Specification v1.0.34](https://theupdateframework.github.io/specification/v1.0.34)
 * [PIP + TUF Integration](https://www.python.org/dev/peps/pep-0458/)

--- a/src/Client/SignatureVerifier.php
+++ b/src/Client/SignatureVerifier.php
@@ -134,7 +134,7 @@ final class SignatureVerifier
      * @param string $keyId
      * @param \Tuf\Key $key
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.33#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.34#document-formats
      */
     public function addKey(string $keyId, Key $key): void
     {

--- a/src/Key.php
+++ b/src/Key.php
@@ -38,7 +38,7 @@ final class Key
      *
      * @return static
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.33#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.34#document-formats
      */
     public static function createFromMetadata(array $keyInfo): self
     {
@@ -59,7 +59,7 @@ final class Key
      * @return string
      *     The key ID in hex format for the key metadata hashed using sha256.
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.33#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.34#document-formats
      *
      * @todo https://github.com/php-tuf/php-tuf/issues/56
      */

--- a/src/Role.php
+++ b/src/Role.php
@@ -35,7 +35,7 @@ class Role
      *
      * @return static
      *
-     * @see https://theupdateframework.github.io/specification/v1.0.33#document-formats
+     * @see https://theupdateframework.github.io/specification/v1.0.34#document-formats
      */
     public static function createFromMetadata(array $roleInfo, string $name): Role
     {

--- a/tests/Unit/RoleTest.php
+++ b/tests/Unit/RoleTest.php
@@ -55,6 +55,8 @@ class RoleTest extends TestCase
             'no keyids' => [['threshold' => 1]],
             'no threshold' => [['keyids' => ['good_key']]],
             'invalid threshold' => [['threshold' => '1', 'keyids' => ['good_key']]],
+            'zero threshold' => [['threshold' => 0, 'keyids' => ['good_key']]],
+            'negative threshold' => [['threshold' => -1, 'keyids' => ['good_key']]],
             'invalid keyids' => [['threshold' => 1, 'keyids' => 'good_key_1,good_key_2']],
             'extra field' => [['threshold' => 1, 'keyids' => ['good_key'], 'extra_field' => 1]],
         ];


### PR DESCRIPTION
Ref #404.

I went through the spec diff between v1.0.33 and v1.0.34: https://github.com/theupdateframework/specification/compare/v1.0.33...v1.0.34

The only normative change is that a role threshold of 0 or less is now explicitly disallowed (theupdateframework/specification#314). PHP-TUF already enforces this: `ConstraintsTrait::getThresholdConstraints()` uses `GreaterThanOrEqual(1)`, and that constraint is applied to root roles, delegated roles and hashed bin delegations. The remaining spec changes are a license switch for the spec document itself and editorial updates, so no behavior changes are needed.

This PR:

- bumps the spec version references in the README, the `@see` links in `src/`, and `tuf-version` in the scheduled specification version check workflow
- adds `zero threshold` and `negative threshold` cases to `RoleTest::providerInvalidMetadata()` to lock in the clarified requirement

The first checklist item in #404 (making sure the scheduled spec check actually runs on this repo) needs someone with access to the Actions settings, since GitHub suspends cron workflows after 60 days without repo activity.

Verified locally: phpunit (451 tests passing), phpcs, phpstan and lint are all clean.
